### PR TITLE
Add `throwHttpErrors` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,11 +98,15 @@ class Ky {
 			credentials: 'same-origin', // TODO: This can be removed when the spec change is implemented in all browsers. Context: https://www.chromestatus.com/feature/4539473312350208
 			retry: 3,
 			timeout: 10000,
+			throwHttpErrors: true,
 			...options
 		};
 
 		this._timeout = this._options.timeout;
 		delete this._options.timeout;
+
+		this._throwHttpErrors = this._options.throwHttpErrors;
+		delete this._options.throwHttpErrors;
 
 		const headers = new window.Headers(this._options.headers || {});
 
@@ -153,7 +157,9 @@ class Ky {
 					return retry();
 				}
 
-				throw error;
+				if (this._throwHttpErrors) {
+					throw error;
+				}
 			}
 		};
 

--- a/index.js
+++ b/index.js
@@ -101,7 +101,6 @@ class Ky {
 		};
 
 		this._timeout = timeout;
-
 		this._throwHttpErrors = throwHttpErrors;
 
 		const headers = new window.Headers(this._options.headers || {});

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,13 @@ Default: `10000`
 
 Timeout in milliseconds for getting a response.
 
+### throwHttpErrors
+
+Type: `boolean`<br>
+Default: `true`
+
+Whether or not an error will be thrown from a HTTP error status.
+
 ### ky.extend(defaultOptions)
 
 Create a new `ky` instance with some defaults overridden with your own.

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,9 @@ Timeout in milliseconds for getting a response.
 Type: `boolean`<br>
 Default: `true`
 
-Whether or not an error will be thrown from a HTTP error status.
+Throw a `HTTPError` for error responses (non-2xx status codes).
+
+Setting this to `false` may be useful if you are checking for resource availability and are expecting error responses.
 
 ### ky.extend(defaultOptions)
 

--- a/test.js
+++ b/test.js
@@ -222,6 +222,16 @@ test('timeout option', async t => {
 	await server.close();
 });
 
+test('throwHttpErrors option', async t => {
+	const server = await createTestServer();
+	server.get('/', (request, response) => {
+		response.sendStatus(500);
+	});
+	await t.notThrowsAsync(ky.get(server.url, {throwHttpErrors: false}).text(), /Internal Server Error/);
+
+	await server.close();
+});
+
 test('ky.extend()', async t => {
 	const server = await createTestServer();
 	server.get('/', (request, response) => {

--- a/test.js
+++ b/test.js
@@ -227,7 +227,11 @@ test('throwHttpErrors option', async t => {
 	server.get('/', (request, response) => {
 		response.sendStatus(500);
 	});
-	await t.notThrowsAsync(ky.get(server.url, {throwHttpErrors: false}).text(), /Internal Server Error/);
+
+	await t.notThrowsAsync(
+		ky.get(server.url, {throwHttpErrors: false}).text(),
+		/Internal Server Error/
+	);
 
 	await server.close();
 });


### PR DESCRIPTION
Fixes #9 

adds `throwHttpErrors` option defaulted to `true` along with updated docs and tests.