### PR TITLE
Feat: convert cjs -> es6 modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,6 @@ const createInstance = (defaults = {}) => {
 	return ky;
 };
 
-module.exports = createInstance();
-module.exports.extend = defaults => createInstance(defaults);
-module.exports.HTTPError = HTTPError;
-module.exports.TimeoutError = TimeoutError;
+export default createInstance();
+export let extend = defaults => createInstance(defaults);
+export { HTTPError, TimeoutError };


### PR DESCRIPTION
Use the now standardized es6 export syntax. You can export the defined default, classes, and any extra function as usual. 