### PR TITLE
Support Ky usage in web workers

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class Ky {
 		this._hooks = hooks;
 		this._throwHttpErrors = throwHttpErrors;
 
-		const headers = new window.Headers(this._options.headers || {});
+		const headers = new self.Headers(this._options.headers || {});
 
 		if (json) {
 			headers.set('content-type', 'application/json');
@@ -164,7 +164,7 @@ class Ky {
 			await hook(this._options);
 		}
 
-		return timeout(window.fetch(this._input, this._options), this._timeout);
+		return timeout(self.fetch(this._input, this._options), this._timeout);
 	}
 }
 

--- a/test/_require.js
+++ b/test/_require.js
@@ -1,6 +1,6 @@
 import fetch, {Headers} from 'node-fetch';
 
-global.window = {
+global.self = {
 	fetch,
 	Headers
 };


### PR DESCRIPTION
Currently, ky cannot be used in web workers because workers don't have a global `window` object. However, all globals used in ky (namely `Headers` and `fetch`) are also available on a worker's `self` scope.

Since `self` also points to the global object in the browser, this PR replaces all occurrences of `window` with `self`, so ky can be used in browsers and web workers alike.