### PR TITLE
Fix relative URL resolution

### DIFF
--- a/cypress/integration/index.js
+++ b/cypress/integration/index.js
@@ -6,6 +6,7 @@ describe('ky', () => {
 			ky('/foo', {prefixUrl: '/'});
 		}).to.throw(Error, /must not begin with a slash/);
 	});
+
 	it('resolves relative URLs for `input` and `prefixUrl`', async () => {
 		expect(await ky('/cypress/fixtures/fixture.json').json()).to.deep.equal({foo: true});
 		expect(await ky('fixtures/fixture.json', {prefixUrl: '/cypress/'}).json()).to.deep.equal({foo: true});

--- a/cypress/integration/index.js
+++ b/cypress/integration/index.js
@@ -6,4 +6,8 @@ describe('ky', () => {
 			ky('/foo', {prefixUrl: '/'});
 		}).to.throw(Error, /must not begin with a slash/);
 	});
+	it('resolves relative URLs for `input` and `prefixUrl`', async () => {
+		expect(await ky('/cypress/fixtures/fixture.json').json()).to.deep.equal({foo: true});
+		expect(await ky('fixtures/fixture.json', {prefixUrl: '/cypress/'}).json()).to.deep.equal({foo: true});
+	});
 });

--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ class Ky {
 			this._options.prefixUrl += '/';
 		}
 
-		const url = new _globalThis.URL(this._options.prefixUrl + this._input);
+		const url = new _globalThis.URL(this._options.prefixUrl + this._input, document.baseURI);
 		if (typeof searchParams === 'string' || searchParams instanceof _globalThis.URLSearchParams) {
 			url.search = searchParams;
 		} else if (searchParams && Object.values(searchParams).every(param => typeof param === 'number' || typeof param === 'string')) {

--- a/test/_require.js
+++ b/test/_require.js
@@ -6,4 +6,6 @@ global.Headers = Headers;
 global.Response = Response;
 global.URL = URL;
 global.URLSearchParams = URLSearchParams;
-global.document = {baseURI: 'http://example.com'};
+global.document = {
+	baseURI: 'https://example.com'
+};

--- a/test/_require.js
+++ b/test/_require.js
@@ -6,3 +6,4 @@ global.Headers = Headers;
 global.Response = Response;
 global.URL = URL;
 global.URLSearchParams = URLSearchParams;
+global.document = {baseURI: 'http://example.com'};


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/ky/issues/58

There was a regression introduced in https://github.com/sindresorhus/ky/commit/a7c71b5728adb5efab59f4057caf83a82453ba4d which broke the ability for `input` to be a relative URL like `foo` or `/foo`. The root cause is that [`window.URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) unfortunately does not support relative URLs without an explicit and absolute `base` argument. This fixes that and adds a test for it. Now that we have Cypress set up, we can properly test anything related to relative URLs.

The goal is to follow the URL resolution rules the same way that `fetch` does. So we resolve `input` against [`document.baseURI`](https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI#The_base_URL_of_a_document).