### PR TITLE
Normalize `method` option value casing

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ class Ky {
 		this._retryCount = 0;
 
 		this._options = {
-			method: 'get',
+			method: 'GET',
 			credentials: 'same-origin', // TODO: This can be removed when the spec change is implemented in all browsers. Context: https://www.chromestatus.com/feature/4539473312350208
 			retry: 2,
 			...otherOptions
@@ -266,7 +266,9 @@ const createInstance = (defaults = {}) => {
 	const ky = (input, options) => new Ky(input, deepMerge({}, defaults, options));
 
 	for (const method of requestMethods) {
-		ky[method] = (input, options) => new Ky(input, deepMerge({}, defaults, options, {method}));
+		ky[method] = (input, options) => new Ky(input, deepMerge({}, defaults, options, {
+			method: method.toUpperCase()
+		}));
 	}
 
 	ky.extend = defaults => createInstance(defaults);

--- a/index.js
+++ b/index.js
@@ -108,13 +108,7 @@ const timeout = (promise, ms) => Promise.race([
 	})()
 ]);
 
-const normalizeRequestMethod = input => {
-	if (requestMethods.includes(input)) {
-		return input.toUpperCase();
-	}
-
-	return input;
-};
+const normalizeRequestMethod = input => requestMethods.includes(input) ? input.toUpperCase() : input;
 
 class Ky {
 	constructor(input, {

--- a/index.js
+++ b/index.js
@@ -108,6 +108,14 @@ const timeout = (promise, ms) => Promise.race([
 	})()
 ]);
 
+const normalizeRequestMethod = input => {
+	if (requestMethods.includes(input)) {
+		return input.toUpperCase();
+	}
+
+	return input;
+};
+
 class Ky {
 	constructor(input, {
 		timeout = 10000,
@@ -120,11 +128,12 @@ class Ky {
 		this._retryCount = 0;
 
 		this._options = {
-			method: 'GET',
+			method: 'get',
 			credentials: 'same-origin', // TODO: This can be removed when the spec change is implemented in all browsers. Context: https://www.chromestatus.com/feature/4539473312350208
 			retry: 2,
 			...otherOptions
 		};
+		this._options.method = normalizeRequestMethod(this._options.method);
 		this._options.prefixUrl = String(this._options.prefixUrl || '');
 		this._input = String(input || '');
 
@@ -266,9 +275,7 @@ const createInstance = (defaults = {}) => {
 	const ky = (input, options) => new Ky(input, deepMerge({}, defaults, options));
 
 	for (const method of requestMethods) {
-		ky[method] = (input, options) => new Ky(input, deepMerge({}, defaults, options, {
-			method: method.toUpperCase()
-		}));
+		ky[method] = (input, options) => new Ky(input, deepMerge({}, defaults, options, {method}));
 	}
 
 	ky.extend = defaults => createInstance(defaults);

--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,10 @@ setTimeout(() => controller.abort(), 5000);
 })();
 ```
 
+### Method name normalization
+
+Ky normalizes the common used method names (`GET`, `POST`, `PATCH`, etc.) in order to avoid server errors due to case sensitivity.
+
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,15 @@ Sets `options.method` to the method name and makes a request.
 
 Type: `Object`
 
+##### method
+
+Type: `String`
+Default: `'GET'`
+
+Sets the method name and makes the request.
+
+Ky normalizes the common used method names (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DELETE`) in order to avoid server errors due to case sensitivity.
+
 ##### json
 
 Type: `Object`
@@ -265,10 +274,6 @@ setTimeout(() => controller.abort(), 5000);
 	}
 })();
 ```
-
-### Method name normalization
-
-Ky normalizes the common used method names (`GET`, `POST`, `PATCH`, etc.) in order to avoid server errors due to case sensitivity.
 
 
 ## FAQ

--- a/readme.md
+++ b/readme.md
@@ -109,9 +109,9 @@ Type: `Object`
 Type: `string`
 Default: `get`
 
-Set the HTTP request method.
+HTTP method used to make the request.
 
-Ky normalizes the common used HTTP request methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DELETE`) in order to avoid server errors due to case sensitivity.
+Internally, the standard methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DELETE`) are uppercased in order to avoid server errors due to case sensitivity.
 
 ##### json
 

--- a/readme.md
+++ b/readme.md
@@ -106,12 +106,12 @@ Type: `Object`
 
 ##### method
 
-Type: `String`
-Default: `'GET'`
+Type: `string`
+Default: `get`
 
-Sets the method name and makes the request.
+Set the HTTP request method.
 
-Ky normalizes the common used method names (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DELETE`) in order to avoid server errors due to case sensitivity.
+Ky normalizes the common used HTTP request methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DELETE`) in order to avoid server errors due to case sensitivity.
 
 ##### json
 

--- a/test/methods.js
+++ b/test/methods.js
@@ -29,11 +29,11 @@ test('custom method remains identical', async t => {
 	});
 
 	await t.notThrowsAsync(() => ky(server.url, {
-		method: 'foo',
+		method: 'report',
 		hooks: {
 			beforeRequest: [
 				options => {
-					t.is(options.method, 'foo');
+					t.is(options.method, 'report');
 				}
 			]
 		}

--- a/test/methods.js
+++ b/test/methods.js
@@ -1,0 +1,43 @@
+import test from 'ava';
+import createTestServer from 'create-test-server';
+import ky from '..';
+
+test('common method is normalized', async t => {
+	const server = await createTestServer();
+	server.all('/', (request, response) => {
+		response.end();
+	});
+
+	await t.notThrowsAsync(() => ky(server.url, {
+		method: 'get',
+		hooks: {
+			beforeRequest: [
+				options => {
+					t.is(options.method, 'GET');
+				}
+			]
+		}
+	}));
+
+	await server.close();
+});
+
+test('custom method remains identical', async t => {
+	const server = await createTestServer();
+	server.all('/', (request, response) => {
+		response.end();
+	});
+
+	await t.notThrowsAsync(() => ky(server.url, {
+		method: 'foo',
+		hooks: {
+			beforeRequest: [
+				options => {
+					t.is(options.method, 'foo');
+				}
+			]
+		}
+	}));
+
+	await server.close();
+});


### PR DESCRIPTION
According to [Fetch specifications](https://fetch.spec.whatwg.org/#concept-method-normalize), method name normalization is currently applied to all but `PATCH`. I personally use this library but in this case, I must override the `method` option in order to fix the issue.

This proposal normalizes shorthand `method` option.