### PR TITLE
[WIP] Fix prefixUrl / input slash mgmt

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,11 +128,11 @@ class Ky {
 		this._options.prefixUrl = String(this._options.prefixUrl || '');
 		this._input = String(input || '');
 
-		if (this._options.prefixUrl && this._input.startsWith('/')) {
-			throw new Error('`input` must not begin with a slash when using `prefixUrl`');
+		if (this._options.prefixUrl && this._input !== '' && !this._input.startsWith('/')) {
+			throw new Error('`input` must begin with a slash when using `prefixUrl`');
 		}
-		if (this._options.prefixUrl && !this._options.prefixUrl.endsWith('/')) {
-			this._options.prefixUrl += '/';
+		if (this._options.prefixUrl && this._options.prefixUrl.endsWith('/')) {
+			throw new Error('`prefixUrl` must not end with a slash');
 		}
 
 		const url = new _globalThis.URL(this._options.prefixUrl + this._input, document.baseURI);

--- a/readme.md
+++ b/readme.md
@@ -131,10 +131,10 @@ import ky from 'ky';
 // On https://example.com
 
 (async () => {
-	await ky('unicorn', {prefixUrl: '/api'});
+	await ky('/unicorn', {prefixUrl: '/api'});
 	//=> 'https://example.com/api/unicorn'
 
-	await ky('unicorn', {prefixUrl: 'https://cats.com'});
+	await ky('/unicorn', {prefixUrl: 'https://cats.com'});
 	//=> 'https://cats.com/unicorn'
 })();
 ```

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Search parameters to include in the request URL. Setting this will override all 
 
 Type: `string` [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL)
 
-When specified, `prefixUrl` will be prepended to `input`. The prefix can be any valid URL, either relative or absolute. A trailing slash `/` is optional, one will be added automatically, if needed, when joining `prefixUrl` and `input`. The `input` argument cannot start with a `/` when using this option.
+When specified, `prefixUrl` will be prepended to `input`. The prefix can be any valid URL, either relative or absolute. No trailing slash `/`, query parameters (`?foo=bar`) or fragment (`#foo=bar`) shall be present. The `input` argument must be empty or start with a `/` when using this option.
 
 Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky-instances.
 

--- a/test/prefix-url.js
+++ b/test/prefix-url.js
@@ -17,18 +17,22 @@ test('prefixUrl option', async t => {
 
 	t.is(await ky(`${server.url}/api/unicorn`, {prefixUrl: false}).text(), 'rainbow');
 	t.is(await ky(`${server.url}/api/unicorn`, {prefixUrl: ''}).text(), 'rainbow');
-	t.is(await ky('api/unicorn', {prefixUrl: server.url}).text(), 'rainbow');
-	t.is(await ky('unicorn', {prefixUrl: `${server.url}/api`}).text(), 'rainbow');
-	t.is(await ky('unicorn', {prefixUrl: `${server.url}/api/`}).text(), 'rainbow');
+	t.is(await ky('/api/unicorn', {prefixUrl: server.url}).text(), 'rainbow');
+	t.is(await ky('/unicorn', {prefixUrl: `${server.url}/api`}).text(), 'rainbow');
+	t.is(await ky('/unicorn', {prefixUrl: `${server.url}/api/`}).text(), 'rainbow');
 	t.is(await ky('', {prefixUrl: server.url}).text(), 'zebra');
-	t.is(await ky('', {prefixUrl: `${server.url}/`}).text(), 'zebra');
+	t.is(await ky('/', {prefixUrl: `${server.url}`}).text(), 'zebra');
 	t.is(await ky('https://cat.com/', {prefixUrl: new URL(`${server.url}/?page=`)}).text(), 'meow');
 	t.is(await ky(new URL('https://cat.com'), {prefixUrl: `${server.url}/?page=`}).text(), 'meow');
 	t.is(await ky(new URL('https://cat.com'), {prefixUrl: new URL(`${server.url}/?page=`)}).text(), 'meow');
 
 	t.throws(() => {
-		ky('/unicorn', {prefixUrl: `${server.url}/api`});
-	}, '`input` must not begin with a slash when using `prefixUrl`');
+		ky('/unicorn', {prefixUrl: `${server.url}/api/`});
+	}, '`prefixUrl` must not end with a slash');
+
+	t.throws(() => {
+		ky('unicorn', {prefixUrl: `${server.url}/api`});
+	}, '`input` must begin with a slash when using `prefixUrl`');
 
 	await server.close();
 });


### PR DESCRIPTION
To be compliant bith the RFC3986 as per the explanation in #70.

The absence of query parameter/fragment could be added.