### PR TITLE
Avoid use of globals where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - '10'
-  - '8'
 after_success:
   - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'

--- a/index.js
+++ b/index.js
@@ -1,19 +1,26 @@
-// Polyfill for `globalThis`
-const _globalThis = (() => {
-	if (typeof self !== 'undefined') {
-		return self;
+const getGlobal = property => {
+	if (typeof self !== 'undefined' && self && property in self) {
+		return self[property];
 	}
 
 	/* istanbul ignore next */
-	if (typeof window !== 'undefined') {
-		return window;
+	if (typeof window !== 'undefined' && window) {
+		if (window.self && property in window.self) {
+			return window.self[property];
+		}
+		if (property in window) {
+			return window[property];
+		}
 	}
 
-	/* istanbul ignore next */
-	if (typeof global !== 'undefined') {
-		return global;
-	}
-})();
+	return global[property];
+};
+
+const URL = getGlobal('URL');
+const URLSearchParams = getGlobal('URLSearchParams');
+const Response = getGlobal('Response');
+const Headers = getGlobal('Headers');
+const fetch = getGlobal('fetch');
 
 const isObject = value => value !== null && typeof value === 'object';
 
@@ -138,11 +145,11 @@ class Ky {
 			this._options.prefixUrl += '/';
 		}
 
-		const url = new _globalThis.URL(this._options.prefixUrl + this._input, document.baseURI);
-		if (typeof searchParams === 'string' || searchParams instanceof _globalThis.URLSearchParams) {
+		const url = new URL(this._options.prefixUrl + this._input, document.baseURI);
+		if (typeof searchParams === 'string' || searchParams instanceof URLSearchParams) {
 			url.search = searchParams;
 		} else if (searchParams && Object.values(searchParams).every(param => typeof param === 'number' || typeof param === 'string')) {
-			url.search = new _globalThis.URLSearchParams(searchParams).toString();
+			url.search = new URLSearchParams(searchParams).toString();
 		} else if (searchParams) {
 			throw new Error('The `searchParams` option must be either a string, `URLSearchParams` instance or an object with string and number values');
 		}
@@ -155,7 +162,7 @@ class Ky {
 		}, hooks);
 		this._throwHttpErrors = throwHttpErrors;
 
-		const headers = new _globalThis.Headers(this._options.headers || {});
+		const headers = new Headers(this._options.headers || {});
 
 		if (json) {
 			headers.set('content-type', 'application/json');
@@ -178,7 +185,7 @@ class Ky {
 					// eslint-disable-next-line no-await-in-loop
 					const modifiedResponse = await hook(response.clone());
 
-					if (modifiedResponse instanceof _globalThis.Response) {
+					if (modifiedResponse instanceof Response) {
 						response = modifiedResponse;
 					}
 				}
@@ -257,7 +264,7 @@ class Ky {
 			await hook(this._options);
 		}
 
-		return timeout(_globalThis.fetch(this._input, this._options), this._timeout);
+		return timeout(fetch(this._input, this._options), this._timeout);
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const getGlobal = property => {
 	return global[property];
 };
 
+const document = getGlobal('document');
 const URL = getGlobal('URL');
 const URLSearchParams = getGlobal('URLSearchParams');
 const Response = getGlobal('Response');
@@ -145,7 +146,7 @@ class Ky {
 			this._options.prefixUrl += '/';
 		}
 
-		const url = new URL(this._options.prefixUrl + this._input, document.baseURI);
+		const url = new URL(this._options.prefixUrl + this._input, document && document.baseURI);
 		if (typeof searchParams === 'string' || searchParams instanceof URLSearchParams) {
 			url.search = searchParams;
 		} else if (searchParams && Object.values(searchParams).every(param => typeof param === 'number' || typeof param === 'string')) {

--- a/index.js
+++ b/index.js
@@ -140,10 +140,10 @@ class Ky {
 			this._options.prefixUrl += '/';
 		}
 
-		// Avoid using URL() if we can, as it does not support relative URLs
-		// and is yet another global to mock in a non-browser environment.
+		this._input = this._options.prefixUrl + this._input;
+
 		if (searchParams) {
-			const url = new URL(this._options.prefixUrl + this._input, document && document.baseURI);
+			const url = new URL(this._input, document && document.baseURI);
 			if (typeof searchParams === 'string' || (URLSearchParams && searchParams instanceof URLSearchParams)) {
 				url.search = searchParams;
 			} else if (Object.values(searchParams).every(param => typeof param === 'number' || typeof param === 'string')) {
@@ -152,8 +152,6 @@ class Ky {
 				throw new Error('The `searchParams` option must be either a string, `URLSearchParams` instance or an object with string and number values');
 			}
 			this._input = url.toString();
-		} else {
-			this._input = this._options.prefixUrl + this._input;
 		}
 
 		this._timeout = timeout;

--- a/index.js
+++ b/index.js
@@ -1,16 +1,12 @@
 const getGlobal = property => {
+	/* istanbul ignore next */
 	if (typeof self !== 'undefined' && self && property in self) {
 		return self[property];
 	}
 
 	/* istanbul ignore next */
-	if (typeof window !== 'undefined' && window) {
-		if (window.self && property in window.self) {
-			return window.self[property];
-		}
-		if (property in window) {
-			return window[property];
-		}
+	if (typeof window !== 'undefined' && window && property in window) {
+		return window[property];
 	}
 
 	return global[property];

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const deepMerge = (...sources) => {
 };
 
 const objectFromEntries = entries => {
-	return entries.reduce((result, [key, value]) => {
+	return [...entries].reduce((result, [key, value]) => {
 		result[key] = value;
 		return result;
 	}, {});

--- a/index.js
+++ b/index.js
@@ -13,8 +13,6 @@ const getGlobal = property => {
 };
 
 const document = getGlobal('document');
-const URL = getGlobal('URL');
-const URLSearchParams = getGlobal('URLSearchParams');
 const Headers = getGlobal('Headers');
 const Response = getGlobal('Response');
 const fetch = getGlobal('fetch');

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const getGlobal = property => {
 const document = getGlobal('document');
 const URL = getGlobal('URL');
 const URLSearchParams = getGlobal('URLSearchParams');
+const Headers = getGlobal('Headers');
 const Response = getGlobal('Response');
 const fetch = getGlobal('fetch');
 
@@ -42,13 +43,6 @@ const deepMerge = (...sources) => {
 	}
 
 	return returnValue;
-};
-
-const objectFromEntries = entries => {
-	return [...entries].reduce((result, [key, value]) => {
-		result[key] = value;
-		return result;
-	}, {});
 };
 
 const requestMethods = [
@@ -171,17 +165,14 @@ class Ky {
 		}, hooks);
 		this._throwHttpErrors = throwHttpErrors;
 
+		const headers = new Headers(this._options.headers || {});
+
 		if (json) {
-			const headers = this._options.headers &&
-				typeof this._options.headers.entries === 'function' ?
-				objectFromEntries(this._options.headers.entries()) :
-				this._options.headers;
-			this._options.headers = {
-				...headers,
-				'content-type': 'application/json'
-			};
+			headers.set('content-type', 'application/json');
 			this._options.body = JSON.stringify(json);
 		}
+
+		this._options.headers = headers;
 
 		this._response = this._fetch();
 

--- a/test/_require.js
+++ b/test/_require.js
@@ -1,11 +1,7 @@
 import {URL, URLSearchParams} from 'url';
-import fetch, {Headers, Response} from 'node-fetch';
+import fetch, {Response} from 'node-fetch';
 
 global.fetch = fetch;
-global.Headers = Headers;
 global.Response = Response;
 global.URL = URL;
 global.URLSearchParams = URLSearchParams;
-global.document = {
-	baseURI: 'https://example.com'
-};

--- a/test/_require.js
+++ b/test/_require.js
@@ -1,7 +1,8 @@
 import {URL, URLSearchParams} from 'url';
-import fetch, {Response} from 'node-fetch';
+import fetch, {Headers, Response} from 'node-fetch';
 
 global.fetch = fetch;
+global.Headers = Headers;
 global.Response = Response;
 global.URL = URL;
 global.URLSearchParams = URLSearchParams;

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -158,14 +158,14 @@ test('afterResponse hook can change response instance by sequence', async t => {
 			{
 				hooks: {
 					afterResponse: [
-						() => new global.Response(modifiedBody1, {
+						() => new Response(modifiedBody1, {
 							status: modifiedStatus1
 						}),
 						async response => {
 							t.is(response.status, modifiedStatus1);
 							t.is(await response.text(), modifiedBody1);
 
-							return new global.Response(modifiedBody2, {
+							return new Response(modifiedBody2, {
 								status: modifiedStatus2
 							});
 						}

--- a/test/main.js
+++ b/test/main.js
@@ -123,6 +123,30 @@ test('custom headers', async t => {
 	await server.close();
 });
 
+test('JSON with custom Headers instance', async t => {
+	t.plan(3);
+
+	const server = await createTestServer();
+	server.post('/', async (request, response) => {
+		t.is(request.headers.unicorn, 'rainbow');
+		t.is(request.headers['content-type'], 'application/json');
+		response.json(JSON.parse(await pBody(request)));
+	});
+
+	const json = {
+		foo: true
+	};
+
+	const responseJson = await ky.post(server.url, {
+		headers: new Headers({unicorn: 'rainbow'}),
+		json
+	}).json();
+
+	t.deepEqual(json, responseJson);
+
+	await server.close();
+});
+
 test('timeout option', async t => {
 	let requestCount = 0;
 
@@ -148,7 +172,7 @@ test('searchParams option', async t => {
 
 	const stringParams = '?pass=true';
 	const objectParams = {pass: 'true'};
-	const searchParams = new global.URLSearchParams(stringParams);
+	const searchParams = new URLSearchParams(stringParams);
 
 	t.is(await ky(server.url, {searchParams: stringParams}).text(), stringParams);
 	t.is(await ky(server.url, {searchParams: objectParams}).text(), stringParams);


### PR DESCRIPTION
Fixes #64 

This is similar to PR #69, however I've taken a different approach. Some of my goals include:
 - No regex testing of URLs.
 - Let `fetch()` handle URL resolution where possible.
 - Guard against `ReferenceError`s by not accessing globals when we don't need them.
 - Simplify testing and mocking by treating `global`, `window`, and `self` as not mutually exclusive.

This should make things significantly easier in non-browser environments. In my testing on Node 10+, I was able to remove everything except for `fetch` and `Response` in [test/_require.js](https://github.com/sindresorhus/ky/blob/master/test/_require.js) and the test suite passed.

Previously, Ky would find the global object and then assume everything lived on that object, which makes things cumbersome in non-DOM / no-browser environments. Now, we lookup each global we need in each namespace. So for example, in Node you don't have to implement all of `window` anymore. If you assign a fetch implementation to `window.fetch` but nothing else, Ky will still be able to find `URL` in modern versions of Node where it lives on `global` and you won't have to assign it manually - it will _just work_.

Further, in all environments, globals are conditionally accessed to avoid unnecessary `ReferenceError`s. Ky also no longer relies on the `Headers` class.