### PR TITLE
Fix the `throwHttpErrors` option for POST requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ class Ky {
 					}
 				}
 
-				if (!response.ok) {
+				if (!response.ok && throwHttpErrors) {
 					throw new HTTPError(response);
 				}
 

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ class Ky {
 		this._response = this._fetch();
 
 		for (const type of responseTypes) {
-			const isRetry = retryMethods.has(this._options.method.toLowerCase());
+			const isRetriableMethod = retryMethods.has(this._options.method.toLowerCase());
 			const fn = async () => {
 				if (this._retryCount > 0) {
 					this._response = this._fetch();
@@ -184,14 +184,14 @@ class Ky {
 					}
 				}
 
-				if (!response.ok && (isRetry || (!isRetry && throwHttpErrors))) {
+				if (!response.ok && (isRetriableMethod || this._throwHttpErrors)) {
 					throw new HTTPError(response);
 				}
 
 				return response.clone()[type]();
 			};
 
-			this._response[type] = isRetry ? this._retry(fn) : fn;
+			this._response[type] = isRetriableMethod ? this._retry(fn) : fn;
 		}
 
 		return this._response;

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ class Ky {
 				}
 
 				return response.clone()[type]();
-			}
+			};
 
 			this._response[type] = isRetry ? this._retry(fn) : fn;
 		}

--- a/test/main.js
+++ b/test/main.js
@@ -180,6 +180,20 @@ test('throwHttpErrors option', async t => {
 	await server.close();
 });
 
+test('throwHttpErrors option with POST', async t => {
+	const server = await createTestServer();
+	server.post('/', (request, response) => {
+		response.sendStatus(500);
+	});
+
+	await t.notThrowsAsync(
+		ky.post(server.url, {throwHttpErrors: false}).text(),
+		/Internal Server Error/
+	);
+
+	await server.close();
+});
+
 test('ky.extend()', async t => {
 	const server = await createTestServer();
 	server.get('/', (request, response) => {


### PR DESCRIPTION
Here is a bug:

When I set `throwHttpErrors` to `false` and then `POST` a request, if the response is not OK, it will still throw `HTTPError`. So I fixed it.