### PR TITLE
Add a UMD build to support older environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn.lock
 .nyc_output
+umd.js

--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
 		"node": ">=10"
 	},
 	"scripts": {
+		"build": "rollup index.js --format umd --name ky --file umd.js",
+		"prepublishOnly": "npm run build",
 		"test": "xo && nyc ava && tsd-check && npm run cypress:run",
 		"cypress:open": "cypress open",
 		"cypress:run": "cypress run"
 	},
 	"files": [
 		"index.js",
-		"index.d.ts"
+		"index.d.ts",
+		"umd.js"
 	],
 	"keywords": [
 		"fetch",
@@ -54,6 +57,7 @@
 		"esm": "^3.0.84",
 		"node-fetch": "^2.3.0",
 		"nyc": "^13.1.0",
+		"rollup": "^1.1.0",
 		"tsd-check": "^0.3.0",
 		"xo": "^0.24.0"
 	},

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=10"
 	},
 	"scripts": {
-		"build": "rollup index.js --format umd --name ky --file umd.js",
+		"build": "rollup index.js --format=umd --name=ky --file=umd.js",
 		"prepublishOnly": "npm run build",
 		"test": "xo && nyc ava && tsd-check && npm run cypress:run",
 		"cypress:open": "cypress open",

--- a/readme.md
+++ b/readme.md
@@ -93,13 +93,13 @@ With plain `fetch`, it would be:
 })();
 ```
 
-In environments that do not support `import`, you can load `ky` in UMD format. For example, using `require()`:
+In environments that do not support `import`, you can load `ky` in [UMD format](https://medium.freecodecamp.org/anatomy-of-js-module-systems-and-building-libraries-fadcd8dbd0e). For example, using `require()`:
 
 ```js
 const ky = require('ky/umd').default;
 ```
 
-This also means `ky` can be used as an AMD module, and if no module system is detected, then `ky` will be available as a global.
+If no module system is detected, then `ky` will be available as a global.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,13 @@ With plain `fetch`, it would be:
 })();
 ```
 
+In environments that do not support `import`, you can load `ky` in UMD format. For example, using `require()`:
+
+```js
+const ky = require('ky/umd').default;
+```
+
+This also means `ky` can be used as an AMD module, and if no module system is detected, then `ky` will be available as a global.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -335,6 +335,21 @@ import ky from 'https://cdn.jsdelivr.net/npm/ky@0.5.2/index.js';
 </script>
 ```
 
+Alternatively, you can use the [`umd.js`](umd.js) file with a traditional `<script>` tag (without `type="module"`), in which case `ky` will be a global.
+
+```html
+<!-- Replace the version number with the latest version -->
+<script src="https://cdn.jsdelivr.net/npm/ky@0.5.2/umd.js">
+<script>
+(async () => {
+	const ky = ky.default;
+	const json = await ky('https://jsonplaceholder.typicode.com/todos/1').json();
+
+	console.log(json.title);
+	//=> 'delectus aut autem
+})();
+</script>
+```
 
 ## Browser support
 

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ In environments that do not support `import`, you can load `ky` in [UMD format](
 const ky = require('ky/umd').default;
 ```
 
-If no module system is detected, then `ky` will be available as a global.
+With the UMD version, it's also easy to use `ky` [without a bundler](#how-do-i-use-this-without-a-bundler-like-webpack) or module system.
 
 ## API
 


### PR DESCRIPTION
Closes #44 

Following the discussions in #44 and #46, we decided to only convert module syntax. This does not transpile the code to ES5, so extremely old environments are still not supported out of the box. Rather, this makes it easy to import ky in non-ESM environments, such as Node.js.

I went with Rollup instead of Babel, because it is simpler to configure and its output is slightly better (easier to read 👀 and no hardcoded AMD ID).