### PR TITLE
Improve type system for get and head methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
 type JSONObject = {[key: string]: JSONValue};
 interface JSONArray extends Array<JSONValue> {}
 export type JSONValue = string | number | boolean | null | JSONObject | JSONArray;

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,11 +77,11 @@ export interface Options extends RequestInit {
 	throwHttpErrors?: boolean;
 }
 
-interface KyOptionsGetHead extends Omit<Options, 'body'> {
+interface OptionsWithoutBody extends Omit<Options, 'body'> {
 	method?: 'get' | 'head'
 }
 
-interface KyOptionsPostPutDelete extends Options {
+interface OptionsWithBody extends Options {
 	method?: 'post' | 'put' | 'delete'
 }
 
@@ -115,7 +115,7 @@ export interface Ky {
 	 * @param input - `Request` object, `URL` object, or URL string.
 	 * @returns Promise with `Body` method added.
 	 */
-	(input: Request | URL | string, options?: KyOptionsGetHead | KyOptionsPostPutDelete): ResponsePromise;
+	(input: Request | URL | string, options?: OptionsWithoutBody | OptionsWithBody): ResponsePromise;
 
 	/**
 	 * Fetches the `input` URL with the option `{method: 'get'}`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 type JSONObject = {[key: string]: JSONValue};
 interface JSONArray extends Array<JSONValue> {}
 export type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
@@ -76,6 +77,14 @@ export interface Options extends RequestInit {
 	throwHttpErrors?: boolean;
 }
 
+interface KyOptionsGetHead extends Omit<Options, 'body'> {
+	method?: 'get' | 'head'
+}
+
+interface KyOptionsPostPutDelete extends Options {
+	method?: 'post' | 'put' | 'delete'
+}
+
 /**
  * Returns a `Response` object with `Body` methods added for convenience.
  */
@@ -106,7 +115,7 @@ export interface Ky {
 	 * @param input - `Request` object, `URL` object, or URL string.
 	 * @returns Promise with `Body` method added.
 	 */
-	(input: Request | URL | string, options?: Options): ResponsePromise;
+	(input: Request | URL | string, options?: KyOptionsGetHead | KyOptionsPostPutDelete): ResponsePromise;
 
 	/**
 	 * Fetches the `input` URL with the option `{method: 'get'}`.
@@ -114,7 +123,7 @@ export interface Ky {
 	 * @param input - `Request` object, `URL` object, or URL string.
 	 * @returns Promise with `Body` method added.
 	 */
-	get(input: Request | URL | string, options?: Options): ResponsePromise;
+	get(input: Request | URL | string, options?: Omit<Options, 'body'>): ResponsePromise;
 
 	/**
 	 * Fetches the `input` URL with the option `{method: 'post'}`.
@@ -146,7 +155,7 @@ export interface Ky {
 	 * @param input - `Request` object, `URL` object, or URL string.
 	 * @returns Promise with `Body` method added.
 	 */
-	head(input: Request | URL | string, options?: Options): ResponsePromise;
+	head(input: Request | URL | string, options?: Omit<Options, 'body'>): ResponsePromise;
 
 	/**
 	 * Fetches the `input` URL with the option `{method: 'delete'}`.

--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ class Ky {
 
 		if (json) {
 			if (this._options.body) {
-				throw new TypeError('The `json` option cannot be used with the `body` option');
+				throw new Error('The `json` option cannot be used with the `body` option');
 			}
 
 			headers.set('content-type', 'application/json');

--- a/index.js
+++ b/index.js
@@ -168,6 +168,10 @@ class Ky {
 		const headers = new Headers(this._options.headers || {});
 
 		if (json) {
+			if (this._options.body) {
+				throw new TypeError('The `json` option cannot be used with the `body` option');
+			}
+
 			headers.set('content-type', 'application/json');
 			this._options.body = JSON.stringify(json);
 		}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -23,9 +23,20 @@ const requestMethods = [
 	'delete'
 ];
 
+const requestBodyMethods = [
+	'post',
+	'put',
+	'delete'
+];
+
 // Test Ky HTTP methods
 requestMethods.map(async key => {
 	expectType<ResponsePromise>(await ky[key](server.url));
+});
+
+// Test Ky HTTP methods with bodies
+requestBodyMethods.map(async key => {
+	expectType<ResponsePromise>(await ky[key](server.url, {body: 'x'}));
 });
 
 expectType<Ky>(ky.extend({}));

--- a/test/main.js
+++ b/test/main.js
@@ -108,6 +108,10 @@ test('POST JSON', async t => {
 	await server.close();
 });
 
+test('cannot use `json` option along with the `body` option', t => {
+	t.throws(() => ky('https://example.com', {json: {foo: 'bar'}, body: 'foobar'}), 'The `json` option cannot be used with the `body` option');
+});
+
 test('custom headers', async t => {
 	const server = await createTestServer();
 	server.get('/', (request, response) => {


### PR DESCRIPTION
Fixes #85

Todo:

 - [x] Do not allow the body option when using `ky.get()` and `ky.head()`
 - [x] Do not allow the body option when using `(…, {method: 'get', body: …})`
 - [x] Disallow the `body` option when the `json` option is used