### PR TITLE
Add generic typing for ResponsePromise.json()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,7 @@ export interface ResponsePromise extends Promise<Response> {
 	arrayBuffer(): Promise<ArrayBuffer>;
 	blob(): Promise<Blob>;
 	formData(): Promise<FormData>;
-	json(): Promise<JSONValue>;
+	json<T = JSONValue>(): Promise<T>;
 	text(): Promise<string>;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,7 @@ export interface ResponsePromise extends Promise<Response> {
 	arrayBuffer(): Promise<ArrayBuffer>;
 	blob(): Promise<Blob>;
 	formData(): Promise<FormData>;
-	json<T = JSONValue>(): Promise<T>;
+	json<T = JSONValue>(): Promise<T | undefined>;
 	text(): Promise<string>;
 }
 


### PR DESCRIPTION
Instead of enforcing `JSONValue`, which very often forces additional casting, let the user choose which value type he wants the result to be.
JSONValue is specified as the default type, so there's no breaking change for code that already expects `json()` to return JSONValue.