### PR TITLE
Fix Error types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -129,7 +129,9 @@ export class HTTPError extends Error {
 /**
  * The error thrown when the request times out.
  */
-export class TimeoutError extends Error {}
+export class TimeoutError extends Error {
+	constructor();
+}
 
 export interface Ky {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,7 @@ export interface ResponsePromise extends Promise<Response> {
  * The error has a response property with the `Response` object.
  */
 export class HTTPError extends Error {
+	constructor(response: Response);
 	response: Response;
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -40,7 +40,7 @@ for (const method of requestBodyMethods) {
 }
 
 expectType<Ky>(ky.extend({}));
-expectType<HTTPError>(new HTTPError());
+expectType<HTTPError>(new HTTPError(new Response));
 expectType<TimeoutError>(new TimeoutError);
 
 ky(server.url, {


### PR DESCRIPTION
Fixes #112 

Adds `constructor` definitions for both `HTTPError` and `TimeoutError`