### PR TITLE
Set accept header for ky shortcut methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,13 +63,13 @@ const requestMethods = [
 	'delete'
 ];
 
-const responseTypes = [
-	'json',
-	'text',
-	'formData',
-	'arrayBuffer',
-	'blob'
-];
+const responseTypes = {
+	json: 'application/json',
+	text: 'text/*',
+	formData: 'multipart/form-data',
+	arrayBuffer: '*/*',
+	blob: '*/*'
+};
 
 const retryMethods = new Set([
 	'get',
@@ -203,6 +203,7 @@ class Ky {
 		this._options.headers = headers;
 
 		const fn = async () => {
+			await delay(1);
 			let response = await this._fetch();
 
 			for (const hook of this._hooks.afterResponse) {
@@ -224,8 +225,9 @@ class Ky {
 		const isRetriableMethod = retryMethods.has(this._options.method.toLowerCase());
 		const result = isRetriableMethod ? this._retry(fn) : fn();
 
-		for (const type of responseTypes) {
+		for (const [type, mimeType] of Object.entries(responseTypes)) {
 			result[type] = async () => {
+				headers.set('accept', mimeType);
 				return (await result).clone()[type]();
 			};
 		}

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ The `input` and `options` are the same as [`fetch`](https://developer.mozilla.or
 - The `credentials` option is `same-origin` by default, which is the default in the spec too, but not all browsers have caught up yet.
 - Adds some more options. See below.
 
-Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, correct `Accept` header will be set depending on body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range `200...299`.
+Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, proper `Accept` header will be set depending on body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range `200...299`.
 
 ### ky.get(input, [options])
 ### ky.post(input, [options])

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ The `input` and `options` are the same as [`fetch`](https://developer.mozilla.or
 - The `credentials` option is `same-origin` by default, which is the default in the spec too, but not all browsers have caught up yet.
 - Adds some more options. See below.
 
-Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range `200...299`.
+Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, correct `Accept` header will be set depending on body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range `200...299`.
 
 ### ky.get(input, [options])
 ### ky.post(input, [options])

--- a/test/methods.js
+++ b/test/methods.js
@@ -41,3 +41,15 @@ test('custom method remains identical', async t => {
 
 	await server.close();
 });
+
+test('shortcut headers have correct accept headers set', async t => {
+	const server = await createTestServer();
+	server.all('/', (request, response) => {
+		t.is(request.headers.accept, 'text/*');
+		response.end('whatever');
+	});
+
+	await ky.get(server.url).text();
+
+	await server.close();
+});


### PR DESCRIPTION
closes #83 

I was first thinking about conditionally setting this inside `ky`s constructor, but it would mean more complexity, as there's no way to know whether the method is set by calling shortcut method or not. We get this for free in `createInstance` function, where shortcut methods are generated, and where I eventually decided to set the header. 
