### PR TITLE
Fix problem with debugging timed-out requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,18 +113,32 @@ class TimeoutError extends Error {
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-const timeout = (promise, ms, abortController) => Promise.race([
-	promise,
-	(async () => {
-		await delay(ms);
-		if (abortController) {
-			// Throw TimeoutError first
-			setTimeout(() => abortController.abort(), 1);
-		}
+const timeout = (promise, ms, abortController) => {
+	let successful = false;
+	return Promise.race([
+		(async () => {
+			try {
+				return await promise;
+			} finally {
+				successful = true;
+			}
+		})(),
+		(async () => {
+			await delay(ms);
 
-		throw new TimeoutError();
-	})()
-]);
+			if (successful) {
+				return;
+			}
+
+			if (abortController) {
+				// Throw TimeoutError first
+				setTimeout(() => abortController.abort(), 1);
+			}
+
+			throw new TimeoutError();
+		})()
+	]);
+};
 
 const normalizeRequestMethod = input => requestMethods.includes(input) ? input.toUpperCase() : input;
 

--- a/index.js
+++ b/index.js
@@ -115,13 +115,13 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 // `Promise.race()` workaround (#91)
 const timeout = (promise, ms, abortController) => new Promise((resolve, reject) => {
-	// eslint-disable promise/prefer-await-to-then
+	/* eslint-disable promise/prefer-await-to-then */
 	promise.then(resolve).catch(reject);
 	delay(ms).then(() => {
 		reject(new TimeoutError());
 		abortController.abort();
 	});
-	// eslint-enable promise/prefer-await-to-then
+	/* eslint-enable promise/prefer-await-to-then */
 });
 
 const normalizeRequestMethod = input => requestMethods.includes(input) ? input.toUpperCase() : input;

--- a/index.js
+++ b/index.js
@@ -115,11 +115,13 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 // `Promise.race()` workaround (#91)
 const timeout = (promise, ms, abortController) => new Promise((resolve, reject) => {
+	// eslint-disable promise/prefer-await-to-then
 	promise.then(resolve).catch(reject);
 	delay(ms).then(() => {
 		reject(new TimeoutError());
 		abortController.abort();
 	});
+	// eslint-enable promise/prefer-await-to-then
 });
 
 const normalizeRequestMethod = input => requestMethods.includes(input) ? input.toUpperCase() : input;


### PR DESCRIPTION
Fixes #91

As discussed in #91 the `TimeoutError` is thrown unconditionally in at least two major browsers. This should only happen if the request hadn’t completed before the timeout. 

Note from @szmarczak: provided a shorter workaround.