### PR TITLE
Fix regression for environments without `AbortController`

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ const timeout = (promise, ms, abortController) => new Promise((resolve, reject) 
 	/* eslint-disable promise/prefer-await-to-then */
 	promise.then(resolve).catch(reject);
 	delay(ms).then(() => {
-		if (abortController) {
+		if (supportsAbortController) {
 			abortController.abort();
 		}
 		reject(new TimeoutError());

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ const timeout = (promise, ms, abortController) => new Promise((resolve, reject) 
 	promise.then(resolve).catch(reject);
 	delay(ms).then(() => {
 		reject(new TimeoutError());
-		abortController.abort();
+		if (abortController) abortController.abort();
 	});
 	/* eslint-enable promise/prefer-await-to-then */
 });

--- a/index.js
+++ b/index.js
@@ -118,8 +118,10 @@ const timeout = (promise, ms, abortController) => new Promise((resolve, reject) 
 	/* eslint-disable promise/prefer-await-to-then */
 	promise.then(resolve).catch(reject);
 	delay(ms).then(() => {
+		if (abortController) {
+			abortController.abort();
+		}
 		reject(new TimeoutError());
-		if (abortController) abortController.abort();
 	});
 	/* eslint-enable promise/prefer-await-to-then */
 });

--- a/index.js
+++ b/index.js
@@ -121,6 +121,7 @@ const timeout = (promise, ms, abortController) => new Promise((resolve, reject) 
 		if (supportsAbortController) {
 			abortController.abort();
 		}
+
 		reject(new TimeoutError());
 	});
 	/* eslint-enable promise/prefer-await-to-then */


### PR DESCRIPTION
#122 removed the check on whether `abortController` exists before calling `abort()`.
This fixes this check for platforms that don't support abortController (e.g. react-native)