### PR TITLE
Fix timeout regression that caused Node.js to not terminate

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,27 +115,34 @@ class TimeoutError extends Error {
 	}
 }
 
-const delay = ms => new Promise((resolve, reject) => {
+function safeTimeout(resolve, ms, reject) {
 	if (ms > 2147483647) { // The maximum value of a 32bit int (see #117)
 		reject(new RangeError('The `timeout` option cannot be greater than 2147483647'));
-	} else {
-		setTimeout(resolve, ms);
 	}
-});
+
+	return setTimeout(resolve, ms);
+}
+
+const delay = ms => new Promise((resolve, reject) => safeTimeout(resolve, ms, reject));
 
 // `Promise.race()` workaround (#91)
-const timeout = (promise, ms, abortController) => new Promise((resolve, reject) => {
-	/* eslint-disable promise/prefer-await-to-then */
-	promise.then(resolve).catch(reject);
-	delay(ms).then(() => {
-		if (supportsAbortController) {
-			abortController.abort();
-		}
+const timeout = (promise, ms, abortController) =>
+	new Promise((resolve, reject) => {
+		const timeoutID = safeTimeout(() => {
+			if (supportsAbortController) {
+				abortController.abort();
+			}
 
-		reject(new TimeoutError());
-	}).catch(reject);
-	/* eslint-enable promise/prefer-await-to-then */
-});
+			reject(new TimeoutError());
+		}, ms, reject);
+
+		/* eslint-disable promise/prefer-await-to-then */
+		promise
+			.then(resolve)
+			.catch(reject)
+			.then(() => clearTimeout(timeoutID));
+		/* eslint-enable promise/prefer-await-to-then */
+	});
 
 const normalizeRequestMethod = input => requestMethods.includes(input) ? input.toUpperCase() : input;
 

--- a/index.js
+++ b/index.js
@@ -140,7 +140,9 @@ const timeout = (promise, ms, abortController) =>
 		promise
 			.then(resolve)
 			.catch(reject)
-			.then(() => clearTimeout(timeoutID));
+			.then(() => {
+				clearTimeout(timeoutID);
+			});
 		/* eslint-enable promise/prefer-await-to-then */
 	});
 

--- a/index.js
+++ b/index.js
@@ -115,15 +115,15 @@ class TimeoutError extends Error {
 	}
 }
 
-function safeTimeout(resolve, ms, reject) {
+const safeTimeout = (resolve, reject, ms) => {
 	if (ms > 2147483647) { // The maximum value of a 32bit int (see #117)
 		reject(new RangeError('The `timeout` option cannot be greater than 2147483647'));
 	}
 
 	return setTimeout(resolve, ms);
-}
+};
 
-const delay = ms => new Promise((resolve, reject) => safeTimeout(resolve, ms, reject));
+const delay = ms => new Promise((resolve, reject) => safeTimeout(resolve, reject, ms));
 
 // `Promise.race()` workaround (#91)
 const timeout = (promise, ms, abortController) =>
@@ -134,7 +134,7 @@ const timeout = (promise, ms, abortController) =>
 			}
 
 			reject(new TimeoutError());
-		}, ms, reject);
+		}, reject, ms);
 
 		/* eslint-disable promise/prefer-await-to-then */
 		promise

--- a/test/main.js
+++ b/test/main.js
@@ -186,13 +186,17 @@ test('timeout:false option', async t => {
 });
 
 test('invalid timeout option', async t => { // #117
+	let requestCount = 0;
+
 	const server = await createTestServer();
 	server.get('/', async (request, response) => {
+		requestCount++;
 		await delay(1000);
 		response.end(fixture);
 	});
 
 	await t.throwsAsync(ky(server.url, {timeout: 21474836470}).text(), RangeError, 'The `timeout` option cannot be greater than 2147483647');
+	t.is(requestCount, 0);
 
 	await server.close();
 });
@@ -305,7 +309,7 @@ test('ky.create() throws when given non-object argument', t => {
 		'hello',
 		[],
 		null,
-		() => {},
+		() => { },
 		Symbol('ky')
 	];
 

--- a/test/main.js
+++ b/test/main.js
@@ -309,7 +309,7 @@ test('ky.create() throws when given non-object argument', t => {
 		'hello',
 		[],
 		null,
-		() => { },
+		() => {},
 		Symbol('ky')
 	];
 

--- a/test/main.js
+++ b/test/main.js
@@ -186,17 +186,31 @@ test('timeout:false option', async t => {
 });
 
 test('invalid timeout option', async t => { // #117
-	let requestCount = 0;
-
 	const server = await createTestServer();
 	server.get('/', async (request, response) => {
-		requestCount++;
 		await delay(1000);
 		response.end(fixture);
 	});
 
 	await t.throwsAsync(ky(server.url, {timeout: 21474836470}).text(), RangeError, 'The `timeout` option cannot be greater than 2147483647');
-	t.is(requestCount, 1);
+
+	await server.close();
+});
+
+test('timeout option is cancelled when the promise is resolved', async t => {
+	const server = await createTestServer();
+
+	server.get('/', (request, response) => {
+		response.end(request.method);
+	});
+
+	const start = new Date().getTime();
+
+	await ky(server.url, {timeout: 2000});
+
+	const duration = start - new Date().getTime();
+
+	t.true(duration < 10);
 
 	await server.close();
 });


### PR DESCRIPTION
Remaining timeout prevents node from terminating the process. These changes clear the timeout on promise resolution.

Closes https://github.com/sindresorhus/ky/issues/138