### PR TITLE
Add `beforeRetry` hook

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,13 @@ export type BeforeRequestHook = (
 	options: NormalizedOptions,
 ) => void | Promise<void>;
 
+export type BeforeRetryHook = (
+	input: Input,
+	options: NormalizedOptions,
+	error: Error,
+	retryCount: number,
+) => void | Promise<void>;
+
 export type AfterResponseHook = (
 	input: Input,
 	options: NormalizedOptions,
@@ -38,6 +45,15 @@ export interface Hooks {
 	@default []
 	*/
 	beforeRequest?: BeforeRequestHook[];
+
+	/**
+	Before the request is retried.
+
+	This hook enables you to modify the request right before retry. The hook function receives the normalized options as the first argument. You could, for example, modify `options.headers` here.
+
+	@default []
+	*/
+	beforeRetry?: BeforeRetryHook[];
 
 	/**
 	After the response is received.

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ export interface Hooks {
 	/**
 	Before the request is retried.
 
-	This hook enables you to modify the request right before retry. The hook function receives the normalized options as the first argument. You could, for example, modify `options.headers` here.
+	This hook enables you to modify the request right before retry. The hook function receives the `input`, `options`, `error` and `retryCount` arguments. You could, for example, modify `options.headers` here.
 
 	@default []
 	*/

--- a/index.js
+++ b/index.js
@@ -255,6 +255,7 @@ class Ky {
 		this._timeout = timeout;
 		this._hooks = deepMerge({
 			beforeRequest: [],
+			beforeRetry: [],
 			afterResponse: []
 		}, hooks);
 		this._throwHttpErrors = throwHttpErrors;
@@ -371,6 +372,17 @@ class Ky {
 			const ms = this._calculateRetryDelay(error);
 			if (ms !== 0 && this._retryCount > 0) {
 				await delay(ms);
+
+				for (const hook of this._hooks.beforeRetry) {
+					// eslint-disable-next-line no-await-in-loop
+					await hook(
+						this._input,
+						this._options,
+						error,
+						this._retryCount,
+					);
+				}
+
 				return this._retry(fn);
 			}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -35,6 +35,15 @@ ky(url, {
 				options.headers.set('foo', 'bar');
 			}
 		],
+		beforeRetry: [
+			(input, options, error, retryCount) => {
+				expectType<Input>(input);
+				expectType<Object>(options);
+				expectType<Error>(error);
+				expectType<number>(retryCount);
+				options.headers.set('foo', 'bar');
+			}
+		],
 		afterResponse: [
 			(input, options, response) => {
 				expectType<Input>(input);

--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,7 @@ If set to `false`, there will be no timeout.
 ##### hooks
 
 Type: `object<string, Function[]>`<br>
-Default: `{beforeRequest: [], afterResponse: []}`
+Default: `{beforeRequest: [], beforeRetry: [], afterResponse: []}`
 
 Hooks allow modifications during the request lifecycle. Hook functions may be async and are run serially.
 
@@ -227,6 +227,31 @@ Default: `[]`
 This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives normalized input and options as arguments. You could, for example, modify `options.headers` here.
 
 Note that the argument order has changed in non-backward compatible way since [#163](https://github.com/sindresorhus/ky/pull/163).
+
+###### hooks.beforeRetry
+
+Type: `Function[]`<br>
+Default: `[]`
+
+This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized input and options, an error instance of the previous request, and retry count as arguments. You could, for example, modify `options.headers` here.
+
+```js
+import ky from 'ky';
+
+(async () => {
+	await ky('https://example.com', {
+		hooks: {
+			beforeRetry: [
+				async (input, options, errors, retryCount) => {
+					// You can modify options, for example, apply a fresh token
+					const token = await ky('https://example.com/refresh-token');
+					options.headers.set('Authorization', `token ${token}`);
+				}
+			]
+		}
+	});
+})();
+```
 
 ###### hooks.afterResponse
 

--- a/readme.md
+++ b/readme.md
@@ -243,7 +243,6 @@ import ky from 'ky';
 		hooks: {
 			beforeRetry: [
 				async (input, options, errors, retryCount) => {
-					// You can modify options, for example, apply a fresh token
 					const token = await ky('https://example.com/refresh-token');
 					options.headers.set('Authorization', `token ${token}`);
 				}

--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,7 @@ If set to `false`, there will be no timeout.
 ##### hooks
 
 Type: `object<string, Function[]>`<br>
-Default: `{beforeRequest: []}`
+Default: `{beforeRequest: [], afterResponse: []}`
 
 Hooks allow modifications during the request lifecycle. Hook functions may be async and are run serially.
 

--- a/readme.md
+++ b/readme.md
@@ -233,7 +233,7 @@ Note that the argument order has changed in non-backward compatible way since [#
 Type: `Function[]`<br>
 Default: `[]`
 
-This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized input and options, an error instance of the previous request, and retry count as arguments. You could, for example, modify `options.headers` here.
+This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized input and options, an error instance and the retry count as arguments. You could, for example, modify `options.headers` here.
 
 ```js
 import ky from 'ky';


### PR DESCRIPTION
Add `beforeRetry` hook just like [got](https://github.com/sindresorhus/got#hooksbeforeretry). I needed it to make sure that an access token is fresh prior to retry.

#### Example usage

```typescript
export const client = ky.extend({
  hooks: {
    beforeRequest: [
      async function(input, options) {
        if (store.refreshRequired) {
          await store.refresh();
        }
        if (store.isAuthorized) {
          (options.headers as Headers).set(
            'X-Authorization',
            `Bearer ${store.accessToken}`,
          );
        }
      },
    ],
    beforeRetry: [
      async function(input, options, errors, retryCount) {
        if (store.refreshRequired) {
          await store.refresh();
        }
        if (store.isAuthorized) {
          (options.headers as Headers).set(
            'X-Authorization',
            `Bearer ${store.accessToken}`,
          );
        }
      },
    ],
  },
});
```