### PR TITLE
Fix the `BeforeRequestHook` TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,11 +96,11 @@ export interface Options extends RequestInit {
 Normalized options passed to the `fetch` call and the beforeRequest hooks.
 */
 interface NormalizedOptions extends RequestInit {
-	// Extended from RequestInit, but ensured to be set (not optional).
+	// Extended from `RequestInit`, but ensured to be set (not optional).
 	method: RequestInit['method'];
 	credentials: RequestInit['credentials'];
 
-	// Extended from custom Ky Options, but ensured to be set (not optional).
+	// Extended from custom Ky `Options`, but ensured to be set (not optional).
 	retry: Options['retry'];
 	prefixUrl: Options['prefixUrl'];
 	onDownloadProgress: Options['onDownloadProgress'];

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 type _Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export type BeforeRequestHook = (options: Options) => void | Promise<void>;
+export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<void>;
 
 export type AfterResponseHook = (response: Response) => Response | void | Promise<Response | void>;
 
@@ -92,12 +92,29 @@ export interface Options extends RequestInit {
 	onDownloadProgress?: (progress: DownloadProgress, chunk: Uint8Array) => void;
 }
 
+/**
+Normalized options passed to the `fetch` call and the beforeRequest hooks.
+*/
+interface NormalizedOptions extends RequestInit {
+	// Extended from RequestInit, but ensured to be set (not optional).
+	method: RequestInit['method'];
+	credentials: RequestInit['credentials'];
+
+	// Extended from custom Ky Options, but ensured to be set (not optional).
+	retry: Options['retry'];
+	prefixUrl: Options['prefixUrl'];
+	onDownloadProgress: Options['onDownloadProgress'];
+
+	// New type.
+	headers: Headers;
+}
+
 interface OptionsWithoutBody extends _Omit<Options, 'body'> {
-	method?: 'get' | 'head'
+	method?: 'get' | 'head';
 }
 
 interface OptionsWithBody extends Options {
-	method?: 'post' | 'put' | 'delete'
+	method?: 'post' | 'put' | 'delete';
 }
 
 /**
@@ -237,6 +254,6 @@ declare const ky: {
 	@returns A new Ky instance.
 	*/
 	extend(defaultOptions: Options): typeof ky;
-}
+};
 
 export default ky;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -45,6 +45,7 @@ ky(url, {
 		beforeRequest: [
 			options => {
 				expectType<Object>(options);
+				options.headers.set('foo', 'bar');
 			}
 		],
 		afterResponse: [


### PR DESCRIPTION
`hooks.beforeRequest` hooks do not receive `Options` but a new set of normalized options with a combination of fetch and ky options, plus a more strict `headers` type.

Re: https://github.com/sindresorhus/ky/issues/139