### PR TITLE
Fix the options TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,10 +96,6 @@ interface OptionsWithoutBody extends _Omit<Options, 'body'> {
 	method?: 'get' | 'head'
 }
 
-interface OptionsWithBody extends Options {
-	method?: 'post' | 'put' | 'delete'
-}
-
 /**
 Returns a `Response` object with `Body` methods added for convenience.
 */
@@ -172,7 +168,7 @@ declare const ky: {
 	})();
 	```
 	*/
-	(url: Request | URL | string, options?: OptionsWithoutBody | OptionsWithBody): ResponsePromise;
+	(url: Request | URL | string, options?: OptionsWithoutBody | Options): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'get'}`.
@@ -180,7 +176,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	get(url: Request | URL | string, options?: _Omit<Options, 'body'>): ResponsePromise;
+	get(url: Request | URL | string, options?: OptionsWithoutBody): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'post'}`.
@@ -212,7 +208,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	head(url: Request | URL | string, options?: _Omit<Options, 'body'>): ResponsePromise;
+	head(url: Request | URL | string, options?: OptionsWithoutBody): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'delete'}`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,7 +92,7 @@ export interface Options extends RequestInit {
 	onDownloadProgress?: (progress: DownloadProgress, chunk: Uint8Array) => void;
 }
 
-interface OptionsWithoutBody extends _Omit<Options, 'body'> {
+interface OptionsWithoutBody extends _Omit<Options, 'body' | 'json'> {
 	method?: 'get' | 'head'
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ export interface Hooks {
 /**
 Options are the same as `window.fetch`, with some exceptions.
 */
-export interface Options extends RequestInit {
+interface KyOptions extends RequestInit {
 	/**
 	Shortcut for sending JSON. Use this instead of the `body` option.
 	*/
@@ -92,9 +92,17 @@ export interface Options extends RequestInit {
 	onDownloadProgress?: (progress: DownloadProgress, chunk: Uint8Array) => void;
 }
 
-interface OptionsWithoutBody extends _Omit<Options, 'body' | 'json'> {
+interface OptionsWithoutBody extends _Omit<KyOptions, 'body' | 'json'> {
 	method?: 'get' | 'head'
 }
+
+interface OptionsWithBody extends KyOptions {
+	method?: 'post' | 'put' | 'delete' | 'patch'
+}
+
+export type Options = OptionsWithoutBody | OptionsWithBody;
+
+export type Input = Request | URL | string;
 
 /**
 Returns a `Response` object with `Body` methods added for convenience.
@@ -168,7 +176,7 @@ declare const ky: {
 	})();
 	```
 	*/
-	(url: Request | URL | string, options?: OptionsWithoutBody | Options): ResponsePromise;
+	(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'get'}`.
@@ -176,7 +184,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	get(url: Request | URL | string, options?: OptionsWithoutBody): ResponsePromise;
+	get(url: Input, options?: OptionsWithoutBody): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'post'}`.
@@ -184,7 +192,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	post(url: Request | URL | string, options?: Options): ResponsePromise;
+	post(url: Input, options?: OptionsWithBody): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'put'}`.
@@ -192,7 +200,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	put(url: Request | URL | string, options?: Options): ResponsePromise;
+	put(url: Input, options?: OptionsWithBody): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'patch'}`.
@@ -200,7 +208,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	patch(url: Request | URL | string, options?: Options): ResponsePromise;
+	patch(url: Input, options?: OptionsWithBody): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'head'}`.
@@ -208,7 +216,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	head(url: Request | URL | string, options?: OptionsWithoutBody): ResponsePromise;
+	head(url: Input, options?: OptionsWithoutBody): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'delete'}`.
@@ -216,7 +224,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	delete(url: Request | URL | string, options?: Options): ResponsePromise;
+	delete(url: Input, options?: OptionsWithBody): ResponsePromise;
 
 	/**
 	Create a new Ky instance with complete new defaults.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress} from '.';
+import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -20,12 +20,14 @@ type Method = typeof requestMethods[number];
 // Test Ky HTTP methods
 for (const method of requestMethods) {
 	expectType<ResponsePromise>(ky[method as Method](url));
+	ky(url, { method });
 }
 
 const requestBodyMethods = [
 	'post',
 	'put',
-	'delete'
+	'delete',
+	'patch'
 ] as const;
 
 type RequestBodyMethod = typeof requestBodyMethods[number];
@@ -33,6 +35,7 @@ type RequestBodyMethod = typeof requestBodyMethods[number];
 // Test Ky HTTP methods with `body`
 for (const method of requestBodyMethods) {
 	expectType<ResponsePromise>(ky[method as RequestBodyMethod](url, {body: 'x'}));
+	ky(url, {method, body: 'x'});
 }
 
 expectType<typeof ky>(ky.create({}));
@@ -58,6 +61,13 @@ ky(url, {
 
 ky(new URL(url));
 ky(new Request(url));
+
+// reusable options
+const options: Options = {
+	method: 'get',
+	timeout: 5000,
+}
+ky(url, options);
 
 // `searchParams` option
 ky(url, {searchParams: 'foo=bar'});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -20,7 +20,7 @@ type Method = typeof requestMethods[number];
 // Test Ky HTTP methods
 for (const method of requestMethods) {
 	expectType<ResponsePromise>(ky[method as Method](url));
-	ky(url, { method });
+	ky(url, {method});
 }
 
 const requestBodyMethods = [
@@ -62,7 +62,7 @@ ky(url, {
 ky(new URL(url));
 ky(new Request(url));
 
-// reusable types
+// Reusable types
 const input: Input = new URL('https://sindresorhus');
 const options: Options = {
 	method: 'get',

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options} from '.';
+import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -62,12 +62,13 @@ ky(url, {
 ky(new URL(url));
 ky(new Request(url));
 
-// reusable options
+// reusable types
+const input: Input = new URL('https://sindresorhus');
 const options: Options = {
 	method: 'get',
 	timeout: 5000,
 }
-ky(url, options);
+ky(input, options);
 
 // `searchParams` option
 ky(url, {searchParams: 'foo=bar'});


### PR DESCRIPTION
The union of `OptionsWithBody` and `OptionsWithoutBody`, both not exported, makes it impossible to reuse an options like so:

```ts
const options: Options = {
  method: 'get'
};
ky(url, options);
```

or if you want to wrap `ky` in your own function:

```ts
function httpClient(input: Input, options: Options) {
  return ky(input, options);
}
```

Given that you can't assign the default `string` method (defined in `Options`) to `'get' | 'head' | 'post' | ...'` expected by the `ky` function.

<img width="1006" alt="Screen Shot 2019-08-09 at 16 23 40" src="https://user-images.githubusercontent.com/474603/62791733-afaa2d80-bac5-11e9-928f-70cf4243936a.png">

Thus, I've exported and refactored both the `Input` and `Options` that make the API of `ky` so one can reuse without conflicts.

----

However, the decision to group these two types of options has the drawback of not supporting other custom HTTP methods (e.g. `trace`, `my-custom-method`). That was already the case, but don't really see the benefit as it's not restricted by the implementation. I.e. in plain JavaScript I can do:

```js
ky(url, {
  method: 'get',
  body: 'test'
});
```

without crashing. Fetch silently handles it.
