### PR TITLE
Pass input/options to beforeRequest/afterResponse hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,11 @@ type Except<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<void>;
 
-export type AfterResponseHook = (response: Response) => Response | void | Promise<Response | void>;
+export type AfterResponseHook = (
+  response: Response,
+  input: Input,
+  options: NormalizedOptions,
+) => Response | void | Promise<Response | void>;
 
 export interface DownloadProgress {
 	percent: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,9 @@ type Except<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<void>;
 
 export type AfterResponseHook = (
-	response: Response,
 	input: Input,
 	options: NormalizedOptions,
+	response: Response,
 ) => Response | void | Promise<Response | void>;
 
 export interface DownloadProgress {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,10 @@
 
 type Except<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<void>;
+export type BeforeRequestHook = (
+	input: Input,
+	options: NormalizedOptions,
+) => void | Promise<void>;
 
 export type AfterResponseHook = (
 	input: Input,

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,9 @@ type Except<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<void>;
 
 export type AfterResponseHook = (
-  response: Response,
-  input: Input,
-  options: NormalizedOptions,
+	response: Response,
+	input: Input,
+	options: NormalizedOptions,
 ) => Response | void | Promise<Response | void>;
 
 export interface DownloadProgress {

--- a/index.js
+++ b/index.js
@@ -250,9 +250,9 @@ class Ky {
 			for (const hook of this._hooks.afterResponse) {
 				// eslint-disable-next-line no-await-in-loop
 				const modifiedResponse = await hook(
-					response.clone(),
 					this._input,
-					this._options
+					this._options,
+					response.clone()
 				);
 
 				if (modifiedResponse instanceof Response) {

--- a/index.js
+++ b/index.js
@@ -249,7 +249,11 @@ class Ky {
 
 			for (const hook of this._hooks.afterResponse) {
 				// eslint-disable-next-line no-await-in-loop
-				const modifiedResponse = await hook(response.clone());
+				const modifiedResponse = await hook(
+					response.clone(),
+					this._input,
+					this._options,
+				);
 
 				if (modifiedResponse instanceof Response) {
 					response = modifiedResponse;

--- a/index.js
+++ b/index.js
@@ -346,7 +346,7 @@ class Ky {
 	async _fetch() {
 		for (const hook of this._hooks.beforeRequest) {
 			// eslint-disable-next-line no-await-in-loop
-			await hook(this._options);
+			await hook(this._input, this._options);
 		}
 
 		if (this._timeout === false) {

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ class Ky {
 				const modifiedResponse = await hook(
 					response.clone(),
 					this._input,
-					this._options,
+					this._options
 				);
 
 				if (modifiedResponse instanceof Response) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -52,7 +52,9 @@ ky(url, {
 			}
 		],
 		afterResponse: [
-			response => {
+			(input, options, response) => {
+				expectType<Input>(input);
+				expectType<Object>(options);
 				expectType<Response>(response);
 				return new Response('Test');
 			}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -46,7 +46,8 @@ expectType<TimeoutError>(new TimeoutError);
 ky(url, {
 	hooks: {
 		beforeRequest: [
-			options => {
+			(input, options) => {
+				expectType<Input>(input);
 				expectType<Object>(options);
 				options.headers.set('foo', 'bar');
 			}

--- a/readme.md
+++ b/readme.md
@@ -237,7 +237,7 @@ import ky from 'ky';
 						// Retry with the token
 						options.headers.set('Authorization', `token ${token}`);
 						
-						return ky(input, {...options});
+						return ky(input, options);
 					}
 				}
 			]

--- a/readme.md
+++ b/readme.md
@@ -211,7 +211,9 @@ This hook enables you to modify the request right before it is sent. Ky will mak
 Type: `Function[]`<br>
 Default: `[]`
 
-This hook enables you to read and optionally modify the response. The hook function receives a clone of the response, normalized input, and normalized options as arguments. The return value of the hook function will be used by Ky as the response object if it's an instance of [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
+This hook enables you to read and optionally modify the response. The hook function receives normalized input, options, and a clone of the response as arguments. The return value of the hook function will be used by Ky as the response object if it's an instance of [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
+
+Note that the argument order has changed in non-backward compatible way since [#163](https://github.com/sindresorhus/ky/pull/163).
 
 ```js
 import ky from 'ky';
@@ -220,7 +222,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			afterResponse: [
-				response => {
+				(_input, _options, response) => {
 					// You could do something with the response, for example, logging.
 					log(response);
 
@@ -229,14 +231,14 @@ import ky from 'ky';
 				},
 
 				// Or retry with a fresh token on a 403 error
-				async (response, input, options) => {
+				async (input, options, response) => {
 					if (response.status === 403) {
 						// Get a fresh token
 						const token = await ky('https://example.com/token').text();
-						
+
 						// Retry with the token
 						options.headers.set('Authorization', `token ${token}`);
-						
+
 						return ky(input, options);
 					}
 				}

--- a/readme.md
+++ b/readme.md
@@ -211,7 +211,7 @@ This hook enables you to modify the request right before it is sent. Ky will mak
 Type: `Function[]`<br>
 Default: `[]`
 
-This hook enables you to read and optionally modify the response. The hook function receives a clone of the response as the first argument. The return value of the hook function will be used by Ky as the response object if it's an instance of [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
+This hook enables you to read and optionally modify the response. The hook function receives a clone of the response, normalized input, and normalized options as arguments. The return value of the hook function will be used by Ky as the response object if it's an instance of [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
 ```js
 import ky from 'ky';
@@ -226,6 +226,18 @@ import ky from 'ky';
 
 					// Or return a `Response` instance to overwrite the response.
 					return new Response('A different response', {status: 200});
+				},
+				// Retry with a fresh token on 403 error
+				async (response, input, options) => {
+					if (response.status === 403) {
+						// Get a fresh token
+						const token = await ky.get('https://example.com/token').text();
+						// Retry with the token
+						options.headers.set('Authorization', `token ${token}`);
+						return ky(input,  {
+							...options,
+						});
+					}
 				}
 			]
 		}

--- a/readme.md
+++ b/readme.md
@@ -227,16 +227,17 @@ import ky from 'ky';
 					// Or return a `Response` instance to overwrite the response.
 					return new Response('A different response', {status: 200});
 				},
-				// Retry with a fresh token on 403 error
+
+				// Or retry with a fresh token on a 403 error
 				async (response, input, options) => {
 					if (response.status === 403) {
 						// Get a fresh token
 						const token = await ky.get('https://example.com/token').text();
+						
 						// Retry with the token
 						options.headers.set('Authorization', `token ${token}`);
-						return ky(input,  {
-							...options,
-						});
+						
+						return ky(input, {...options});
 					}
 				}
 			]

--- a/readme.md
+++ b/readme.md
@@ -217,7 +217,7 @@ This hook enables you to read and optionally modify the response. The hook funct
 import ky from 'ky';
 
 (async () => {
-	await ky.get('https://example.com', {
+	await ky('https://example.com', {
 		hooks: {
 			afterResponse: [
 				response => {
@@ -232,7 +232,7 @@ import ky from 'ky';
 				async (response, input, options) => {
 					if (response.status === 403) {
 						// Get a fresh token
-						const token = await ky.get('https://example.com/token').text();
+						const token = await ky('https://example.com/token').text();
 						
 						// Retry with the token
 						options.headers.set('Authorization', `token ${token}`);

--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,9 @@ Hooks allow modifications during the request lifecycle. Hook functions may be as
 Type: `Function[]`<br>
 Default: `[]`
 
-This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives the normalized options as the first argument. You could, for example, modify `options.headers` here.
+This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives normalized input and options as arguments. You could, for example, modify `options.headers` here.
+
+Note that the argument order has changed in non-backward compatible way since [#163](https://github.com/sindresorhus/ky/pull/163).
 
 ###### hooks.afterResponse
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -23,7 +23,7 @@ test('hooks can be async', async t => {
 			json,
 			hooks: {
 				beforeRequest: [
-					async options => {
+					async (_input, options) => {
 						await delay(100);
 						const bodyJson = JSON.parse(options.body);
 						bodyJson.foo = false;
@@ -70,7 +70,7 @@ test('beforeRequest hook allows modifications', async t => {
 			json,
 			hooks: {
 				beforeRequest: [
-					options => {
+					(_input, options) => {
 						const bodyJson = JSON.parse(options.body);
 						bodyJson.foo = false;
 						options.body = JSON.stringify(bodyJson);

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -101,7 +101,7 @@ test('afterResponse hook accept success response', async t => {
 			json,
 			hooks: {
 				afterResponse: [
-					async response => {
+					async (_input, _options, response) => {
 						t.is(response.status, 200);
 						t.deepEqual(await response.json(), json);
 					}
@@ -129,7 +129,7 @@ test('afterResponse hook accept fail response', async t => {
 			json,
 			hooks: {
 				afterResponse: [
-					async response => {
+					async (_input, _options, response) => {
 						t.is(response.status, 500);
 						t.deepEqual(await response.json(), json);
 					}
@@ -161,7 +161,7 @@ test('afterResponse hook can change response instance by sequence', async t => {
 						() => new Response(modifiedBody1, {
 							status: modifiedStatus1
 						}),
-						async response => {
+						async (_input, _options, response) => {
 							t.is(response.status, modifiedStatus1);
 							t.is(await response.text(), modifiedBody1);
 
@@ -233,7 +233,7 @@ test('`afterResponse` hook gets called even if using body shortcuts', async t =>
 	await ky.get(server.url, {
 		hooks: {
 			afterResponse: [
-				response => {
+				(_input, _options, response) => {
 					called = true;
 					return response;
 				}
@@ -246,7 +246,7 @@ test('`afterResponse` hook gets called even if using body shortcuts', async t =>
 	await server.close();
 });
 
-test('`afterResponse` hook is called with response, input, and normalized options which can be used to retry', async t => {
+test('`afterResponse` hook is called with input, normalized options, and response which can be used to retry', async t => {
 	const server = await createTestServer();
 	server.post('/', async (request, response) => {
 		const body = await pBody(request);
@@ -269,7 +269,7 @@ test('`afterResponse` hook is called with response, input, and normalized option
 			json,
 			hooks: {
 				afterResponse: [
-					async (response, input, options) => {
+					async (input, options, response) => {
 						if (response.status === 403) {
 							// Retry request with valid token
 							return ky(input, {

--- a/test/methods.js
+++ b/test/methods.js
@@ -12,7 +12,7 @@ test('common method is normalized', async t => {
 		method: 'get',
 		hooks: {
 			beforeRequest: [
-				options => {
+				(_input, options) => {
 					t.is(options.method, 'GET');
 				}
 			]
@@ -32,7 +32,7 @@ test('custom method remains identical', async t => {
 		method: 'report',
 		hooks: {
 			beforeRequest: [
-				options => {
+				(_input, options) => {
 					t.is(options.method, 'report');
 				}
 			]


### PR DESCRIPTION
I needed to access `input` and `options` on `afterResponse` hook to perform retry with a fresh access  token like:

```js
import ky from 'ky';

(async () => {
  await ky.get('https://example.com', {
    hooks: {
      afterResponse: [
	async (input, options, response) => {
	  if (response.status === 403) {
	    // Get a fresh token
	    const token = await ky.get('https://example.com/token').text();
	    // Retry with the token
	    options.headers.set('Authorization', `token ${token}`);
	    return ky(input,  {
	      ...options,
	    });
	  }
	}
      ]
    }
  });
})();
```

I noticed https://github.com/sindresorhus/ky/pull/136 after I wrote the code but the PR seems not updated and ~backword incompatible (arguments order)~ so I decided to make this PR.

**Updated**

- [x] The order become `input, options, response`
- [x] Applied to `beforeRequest` as well