### PR TITLE
Simplify the `Options` TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,10 @@
 /// <reference lib="dom"/>
 
+type Primitive = null | undefined | string | number | boolean | symbol | bigint;
+type LiteralUnion<LiteralType extends BaseType, BaseType extends Primitive> =
+	| LiteralType
+	| (BaseType & { _?: never });
+
 export type Input = Request | URL | string;
 
 export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<void>;
@@ -40,6 +45,14 @@ export interface Hooks {
 Options are the same as `window.fetch`, with some exceptions.
 */
 export interface Options extends RequestInit {
+	/**
+	HTTP request method.
+	*/
+	method?: LiteralUnion<
+		'get' | 'head' | 'post' | 'put' | 'delete' | 'connect' | 'options' | 'trace' | 'patch',
+		string
+	>;
+
 	/**
 	Shortcut for sending JSON. Use this instead of the `body` option.
 	*/
@@ -192,6 +205,14 @@ declare const ky: {
 	get(url: Input, options?: Options): ResponsePromise;
 
 	/**
+	Fetch the given `url` using the option `{method: 'head'}`.
+
+	@param url - `Request` object, `URL` object, or URL string.
+	@returns A promise with `Body` methods added.
+	*/
+	head(url: Input, options?: Options): ResponsePromise;
+
+	/**
 	Fetch the given `url` using the option `{method: 'post'}`.
 
 	@param url - `Request` object, `URL` object, or URL string.
@@ -208,28 +229,44 @@ declare const ky: {
 	put(url: Input, options?: Options): ResponsePromise;
 
 	/**
-	Fetch the given `url` using the option `{method: 'patch'}`.
-
-	@param url - `Request` object, `URL` object, or URL string.
-	@returns A promise with `Body` methods added.
-	*/
-	patch(url: Input, options?: Options): ResponsePromise;
-
-	/**
-	Fetch the given `url` using the option `{method: 'head'}`.
-
-	@param url - `Request` object, `URL` object, or URL string.
-	@returns A promise with `Body` methods added.
-	*/
-	head(url: Input, options?: Options): ResponsePromise;
-
-	/**
 	Fetch the given `url` using the option `{method: 'delete'}`.
 
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
 	delete(url: Input, options?: Options): ResponsePromise;
+
+	/**
+	Fetch the given `url` using the option `{method: 'connect'}`.
+
+	@param url - `Request` object, `URL` object, or URL string.
+	@returns A promise with `Body` methods added.
+	*/
+	connect(url: Input, options?: Options): ResponsePromise;
+
+		/**
+	Fetch the given `url` using the option `{method: 'options'}`.
+
+	@param url - `Request` object, `URL` object, or URL string.
+	@returns A promise with `Body` methods added.
+	*/
+	options(url: Input, options?: Options): ResponsePromise;
+
+	/**
+	Fetch the given `url` using the option `{method: 'trace'}`.
+
+	@param url - `Request` object, `URL` object, or URL string.
+	@returns A promise with `Body` methods added.
+	*/
+	trace(url: Input, options?: Options): ResponsePromise;
+
+	/**
+	Fetch the given `url` using the option `{method: 'patch'}`.
+
+	@param url - `Request` object, `URL` object, or URL string.
+	@returns A promise with `Body` methods added.
+	*/
+	patch(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Create a new Ky instance with complete new defaults.

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ export interface Options extends RequestInit {
 	/**
 	HTTP request method.
 	*/
-	method?: LiteralUnion<'get' | 'head' | 'post' | 'put' | 'delete' | 'options' | 'patch', string>;
+	method?: LiteralUnion<'get' | 'post' | 'put' | 'delete' | 'patch' | 'head', string>;
 
 	/**
 	Shortcut for sending JSON. Use this instead of the `body` option.
@@ -202,14 +202,6 @@ declare const ky: {
 	get(url: Input, options?: Options): ResponsePromise;
 
 	/**
-	Fetch the given `url` using the option `{method: 'head'}`.
-
-	@param url - `Request` object, `URL` object, or URL string.
-	@returns A promise with `Body` methods added.
-	*/
-	head(url: Input, options?: Options): ResponsePromise;
-
-	/**
 	Fetch the given `url` using the option `{method: 'post'}`.
 
 	@param url - `Request` object, `URL` object, or URL string.
@@ -234,20 +226,20 @@ declare const ky: {
 	delete(url: Input, options?: Options): ResponsePromise;
 
 	/**
-	Fetch the given `url` using the option `{method: 'options'}`.
-
-	@param url - `Request` object, `URL` object, or URL string.
-	@returns A promise with `Body` methods added.
-	*/
-	options(url: Input, options?: Options): ResponsePromise;
-
-	/**
 	Fetch the given `url` using the option `{method: 'patch'}`.
 
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
 	patch(url: Input, options?: Options): ResponsePromise;
+
+	/**
+	Fetch the given `url` using the option `{method: 'head'}`.
+
+	@param url - `Request` object, `URL` object, or URL string.
+	@returns A promise with `Body` methods added.
+	*/
+	head(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Create a new Ky instance with complete new defaults.

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,10 +48,7 @@ export interface Options extends RequestInit {
 	/**
 	HTTP request method.
 	*/
-	method?: LiteralUnion<
-		'get' | 'head' | 'post' | 'put' | 'delete' | 'connect' | 'options' | 'trace' | 'patch',
-		string
-	>;
+	method?: LiteralUnion<'get' | 'head' | 'post' | 'put' | 'delete' | 'options' | 'patch', string>;
 
 	/**
 	Shortcut for sending JSON. Use this instead of the `body` option.
@@ -237,28 +234,12 @@ declare const ky: {
 	delete(url: Input, options?: Options): ResponsePromise;
 
 	/**
-	Fetch the given `url` using the option `{method: 'connect'}`.
-
-	@param url - `Request` object, `URL` object, or URL string.
-	@returns A promise with `Body` methods added.
-	*/
-	connect(url: Input, options?: Options): ResponsePromise;
-
-		/**
 	Fetch the given `url` using the option `{method: 'options'}`.
 
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
 	options(url: Input, options?: Options): ResponsePromise;
-
-	/**
-	Fetch the given `url` using the option `{method: 'trace'}`.
-
-	@param url - `Request` object, `URL` object, or URL string.
-	@returns A promise with `Body` methods added.
-	*/
-	trace(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'patch'}`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom"/>
 
-type Except<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type Input = Request | URL | string;
 
 export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<void>;
 
@@ -39,7 +39,7 @@ export interface Hooks {
 /**
 Options are the same as `window.fetch`, with some exceptions.
 */
-interface KyOptions extends RequestInit {
+export interface Options extends RequestInit {
 	/**
 	Shortcut for sending JSON. Use this instead of the `body` option.
 	*/
@@ -101,25 +101,13 @@ interface NormalizedOptions extends RequestInit {
 	credentials: RequestInit['credentials'];
 
 	// Extended from custom `KyOptions`, but ensured to be set (not optional).
-	retry: KyOptions['retry'];
-	prefixUrl: KyOptions['prefixUrl'];
-	onDownloadProgress: KyOptions['onDownloadProgress'];
+	retry: Options['retry'];
+	prefixUrl: Options['prefixUrl'];
+	onDownloadProgress: Options['onDownloadProgress'];
 
 	// New type.
 	headers: Headers;
 }
-
-interface OptionsWithoutBody extends Except<KyOptions, 'body' | 'json'> {
-	method?: 'get' | 'head';
-}
-
-interface OptionsWithBody extends KyOptions {
-	method?: 'post' | 'put' | 'delete' | 'patch'
-}
-
-export type Options = OptionsWithoutBody | OptionsWithBody;
-
-export type Input = Request | URL | string;
 
 /**
 Returns a `Response` object with `Body` methods added for convenience.
@@ -201,7 +189,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	get(url: Input, options?: OptionsWithoutBody): ResponsePromise;
+	get(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'post'}`.
@@ -209,7 +197,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	post(url: Input, options?: OptionsWithBody): ResponsePromise;
+	post(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'put'}`.
@@ -217,7 +205,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	put(url: Input, options?: OptionsWithBody): ResponsePromise;
+	put(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'patch'}`.
@@ -225,7 +213,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	patch(url: Input, options?: OptionsWithBody): ResponsePromise;
+	patch(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'head'}`.
@@ -233,7 +221,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	head(url: Input, options?: OptionsWithoutBody): ResponsePromise;
+	head(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Fetch the given `url` using the option `{method: 'delete'}`.
@@ -241,7 +229,7 @@ declare const ky: {
 	@param url - `Request` object, `URL` object, or URL string.
 	@returns A promise with `Body` methods added.
 	*/
-	delete(url: Input, options?: OptionsWithBody): ResponsePromise;
+	delete(url: Input, options?: Options): ResponsePromise;
 
 	/**
 	Create a new Ky instance with complete new defaults.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,10 @@
 /// <reference lib="dom"/>
 
 type Primitive = null | undefined | string | number | boolean | symbol | bigint;
+
 type LiteralUnion<LiteralType extends BaseType, BaseType extends Primitive> =
 	| LiteralType
-	| (BaseType & { _?: never });
+	| (BaseType & {_?: never});
 
 export type Input = Request | URL | string;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -56,13 +56,13 @@ const options: Options = {
 }
 ky(input, options);
 
-// Wrapping ky
+// Extending ky
 interface CustomOptions extends Options {
 	foo?: boolean;
 }
 async function customKy(input: Input, options?: CustomOptions) {
 	if (options && options.foo) {
-		options.json = options.foo;
+		options.json = { foo: options.foo };
 	}
 	return ky(input, options);
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,12 +8,11 @@ expectType<ResponsePromise>(ky(url));
 
 const requestMethods = [
 	'get',
-	'head',
 	'post',
 	'put',
 	'delete',
-	'options',
 	'patch',
+	'head',
 ] as const;
 
 // Test Ky HTTP methods

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,18 +8,19 @@ expectType<ResponsePromise>(ky(url));
 
 const requestMethods = [
 	'get',
+	'head',
 	'post',
 	'put',
+	'delete',
+	'connect',
+	'options',
+	'trace',
 	'patch',
-	'head',
-	'delete'
 ] as const;
-
-type Method = typeof requestMethods[number];
 
 // Test Ky HTTP methods
 for (const method of requestMethods) {
-	expectType<ResponsePromise>(ky[method as Method](url));
+	expectType<ResponsePromise>(ky[method](url));
 	ky(url, {method});
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -61,7 +61,7 @@ interface CustomOptions extends Options {
 	foo?: boolean;
 }
 async function customKy(input: Input, options?: CustomOptions) {
-	if (options.foo) {
+	if (options && options.foo) {
 		options.json = options.foo;
 	}
 	return ky(input, options);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -23,21 +23,6 @@ for (const method of requestMethods) {
 	ky(url, {method});
 }
 
-const requestBodyMethods = [
-	'post',
-	'put',
-	'delete',
-	'patch'
-] as const;
-
-type RequestBodyMethod = typeof requestBodyMethods[number];
-
-// Test Ky HTTP methods with `body`
-for (const method of requestBodyMethods) {
-	expectType<ResponsePromise>(ky[method as RequestBodyMethod](url, {body: 'x'}));
-	ky(url, {method, body: 'x'});
-}
-
 expectType<typeof ky>(ky.create({}));
 expectType<typeof ky>(ky.extend({}));
 expectType<HTTPError>(new HTTPError(new Response));
@@ -70,6 +55,18 @@ const options: Options = {
 	timeout: 5000,
 }
 ky(input, options);
+
+// Wrapping ky
+interface CustomOptions extends Options {
+	foo?: boolean;
+}
+async function customKy(input: Input, options?: CustomOptions) {
+	if (options.foo) {
+		options.json = options.foo;
+	}
+	return ky(input, options);
+}
+customKy(input, options);
 
 // `searchParams` option
 ky(url, {searchParams: 'foo=bar'});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,9 +12,7 @@ const requestMethods = [
 	'post',
 	'put',
 	'delete',
-	'connect',
 	'options',
-	'trace',
 	'patch',
 ] as const;
 


### PR DESCRIPTION
Fixes #164 

See discussion in issue above.

This PR:
* makes reusing, extending and manipulating `Options` type more flexible;
* adds support for custom HTTP verbs/methods;
* aligns `ky`'s API with the native `fetch`.