### PR TITLE
Allow returning `Response` from a `beforeRequest` hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,7 +383,10 @@ class Ky {
 	async _fetch() {
 		for (const hook of this._hooks.beforeRequest) {
 			// eslint-disable-next-line no-await-in-loop
-			await hook(this._input, this._options);
+			const hookOutput = await hook(this._input, this._options);
+			if (hookOutput instanceof Response) {
+				return hookOutput;
+			}
 		}
 
 		if (this._timeout === false) {

--- a/index.js
+++ b/index.js
@@ -383,10 +383,10 @@ class Ky {
 	async _fetch() {
 		for (const hook of this._hooks.beforeRequest) {
 			// eslint-disable-next-line no-await-in-loop
-			const hookOutput = await hook(this._input, this._options);
+			const result = await hook(this._input, this._options);
 
-			if (hookOutput instanceof Response) {
-				return hookOutput;
+			if (result instanceof Response) {
+				return result;
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -384,6 +384,7 @@ class Ky {
 		for (const hook of this._hooks.beforeRequest) {
 			// eslint-disable-next-line no-await-in-loop
 			const hookOutput = await hook(this._input, this._options);
+
 			if (hookOutput instanceof Response) {
 				return hookOutput;
 			}

--- a/readme.md
+++ b/readme.md
@@ -226,7 +226,9 @@ Default: `[]`
 
 This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives normalized input and options as arguments. You could, for example, modify `options.headers` here.
 
-A [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) can be returned from a beforeRequest hook and completely avoid making an HTTP request. This can be used to mock a request, check an internal cache, etc. An **IMPORTANT** consideration when returning a Response from this hook is that, all the following hooks will be skipped, so be **sure to only return a Response from the last one**.
+A [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) instance can be returned from a `beforeRequest` hook to completely avoid making an HTTP request. This is very helpful when mocking a request or using an internal cache.
+
+**Note:** all the following hooks will be skipped.
 
 Note that the argument order has changed in non-backward compatible way since [#163](https://github.com/sindresorhus/ky/pull/163).
 

--- a/readme.md
+++ b/readme.md
@@ -226,6 +226,8 @@ Default: `[]`
 
 This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives normalized input and options as arguments. You could, for example, modify `options.headers` here.
 
+A [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) can be returned from a beforeRequest hook and completely avoid making an HTTP request. This can be used to mock a request, check an internal cache, etc. An **IMPORTANT** consideration when returning a Response from this hook is that, all the following hooks will be skipped, so be **sure to only return a Response from the last one**.
+
 Note that the argument order has changed in non-backward compatible way since [#163](https://github.com/sindresorhus/ky/pull/163).
 
 ###### hooks.afterResponse

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -291,3 +291,15 @@ test.failing('`afterResponse` hook is called with input, normalized options, and
 
 	await server.close();
 });
+
+test('hooks beforeRequest returning Response skips HTTP Request', async t => {
+	const expectedResponse = 'empty hook';
+
+	const response = await ky.get('server.url', {hooks: {
+		beforeRequest: [
+			() => new Response(expectedResponse, {status: 200, statusText: 'OK'})
+		]
+	}}).text();
+
+	t.is(response, expectedResponse);
+});


### PR DESCRIPTION
This PR adds support to return a Response from the beforeRequest hook and completely skip the HTTP request.
 
closes #157 

/cc @lidel