### PR TITLE
Validate the `input` argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,6 +242,8 @@ class Ky {
 				body: otherOptions.body || input.body,
 				credentials: otherOptions.credentials || input.credentials
 			};
+		} else if (!(input instanceof URL) && typeof input !== 'string') {
+			throw new Error('`input` must be a string, URL, or Request');
 		} else {
 			this._input = String(input || '');
 			this._options.prefixUrl = String(this._options.prefixUrl || '');

--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ class Ky {
 				credentials: otherOptions.credentials || input.credentials
 			};
 		} else if (!(input instanceof URL) && typeof input !== 'string') {
-			throw new Error('`input` must be a string, URL, or Request');
+			throw new TypeError('`input` must be a string, URL, or Request');
 		} else {
 			this._input = String(input || '');
 			this._options.prefixUrl = String(this._options.prefixUrl || '');

--- a/test/main.js
+++ b/test/main.js
@@ -429,6 +429,10 @@ test('supports Request instance as input', async t => {
 	await server.close();
 });
 
+test('throws when input is not a string, URL, or Request', t => {
+	t.throws(() => ky.get(0), '`input` must be a string, URL, or Request');
+});
+
 test('options override Request instance method', async t => {
 	const server = await createTestServer();
 	const inputRequest = new Request(server.url, {method: 'GET'});

--- a/test/main.js
+++ b/test/main.js
@@ -430,7 +430,9 @@ test('supports Request instance as input', async t => {
 });
 
 test('throws when input is not a string, URL, or Request', t => {
-	t.throws(() => ky.get(0), '`input` must be a string, URL, or Request');
+	t.throws(() => {
+		ky.get(0);
+	}, '`input` must be a string, URL, or Request');
 });
 
 test('options override Request instance method', async t => {


### PR DESCRIPTION
Display a meaningful error to the user if they attempt to provide an invalid input (for example, a `Number`).

Resolves #174 