### PR TITLE
Use request to normalize options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,19 +9,19 @@ type LiteralUnion<LiteralType extends BaseType, BaseType extends Primitive> =
 export type Input = Request | URL | string;
 
 export type BeforeRequestHook = (
-	input: Input,
+	request: Request,
 	options: NormalizedOptions,
-) => Response | void | Promise<Response | void>;
+) => Request | Response | void | Promise<Request | Response | void>;
 
 export type BeforeRetryHook = (
-	input: Input,
+	request: Request,
 	options: NormalizedOptions,
 	error: Error,
 	retryCount: number,
 ) => void | Promise<void>;
 
 export type AfterResponseHook = (
-	input: Input,
+	request: Request,
 	options: NormalizedOptions,
 	response: Response,
 ) => Response | void | Promise<Response | void>;

--- a/index.js
+++ b/index.js
@@ -309,7 +309,7 @@ class Ky {
 				// eslint-disable-next-line no-await-in-loop
 				const modifiedResponse = await hook(
 					this.request,
-					this._options,
+					this._fetchOptions,
 					response.clone()
 				);
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -29,37 +29,43 @@ expectType<TimeoutError>(new TimeoutError);
 ky(url, {
 	hooks: {
 		beforeRequest: [
-			(input, options) => {
-				expectType<Input>(input);
+			(request, options) => {
+				expectType<Request>(request);
 				expectType<Object>(options);
-				options.headers.set('foo', 'bar');
+				request.headers.set('foo', 'bar');
 			},
-			(_input, _options) => {
+			(_request, _options) => {
+				return new Request('Test');
+			},
+			async (_request, _options) => {
+				return new Request('Test');
+			},
+			(_request, _options) => {
 				return new Response('Test');
 			},
-			async (_input, _options) => {
+			async (_request, _options) => {
 				return new Response('Test');
 			}
 		],
 		beforeRetry: [
-			(input, options, error, retryCount) => {
-				expectType<Input>(input);
+			(request, options, error, retryCount) => {
+				expectType<Request>(request);
 				expectType<Object>(options);
 				expectType<Error>(error);
 				expectType<number>(retryCount);
-				options.headers.set('foo', 'bar');
+				request.headers.set('foo', 'bar');
 			}
 		],
 		afterResponse: [
-			(input, options, response) => {
-				expectType<Input>(input);
+			(request, options, response) => {
+				expectType<Request>(request);
 				expectType<Object>(options);
 				expectType<Response>(response);
 			},
-			(_input, _options, _response) => {
+			(_request, _options, _response) => {
 				return new Response('Test');
 			},
-			async (_input, _options, _response) => {
+			async (_request, _options, _response) => {
 				return new Response('Test');
 			}
 		]

--- a/readme.md
+++ b/readme.md
@@ -154,7 +154,7 @@ Search parameters to include in the request URL. Setting this will override all 
 
 Type: `string | URL`
 
-When specified, `prefixUrl` will be prepended to `input`. The prefix can be any valid URL, either relative or absolute. A trailing slash `/` is optional, one will be added automatically, if needed, when joining `prefixUrl` and `input`. The `input` argument cannot start with a `/` when using this option.
+A prefix URL to prepend to the `input` argument, when `input` is a string. The prefix can be any valid URL, either relative or absolute. A trailing `/` slash is optional and will be added automatically, if needed, when it is joined with `input`. When using a prefix, `input` cannot start with a `/` slash.
 
 Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky-instances.
 

--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/R
 
 Sets `options.method` to the method name and makes a request.
 
-When using a `Request` instance as `input`, any URL altering options (example: `prefixUrl`)  will not work.
+When using a `Request` instance as `input`, any URL altering options (such as `prefixUrl`) will be ignored.
 
 #### options
 
@@ -224,16 +224,16 @@ Hooks allow modifications during the request lifecycle. Hook functions may be as
 Type: `Function[]`<br>
 Default: `[]`
 
-This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives normalized input and options as arguments. You could, for example, modify `options.headers` here.
+This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives `request` and `options` as arguments. You could, for example, modify the `request.headers` here.
 
-A [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) can be returned from this hook to completely avoid making a HTTP request. This can be used to mock a request, check an internal cache, etc. An **important** consideration when returning a `Response` from this hook is that all the following hooks will be skipped, so **ensure you only return a `Response` from the last hook**.
+The hook can return a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) to replace the outgoing request, or return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) to completely avoid making an HTTP request. This can be used to mock a request, check an internal cache, etc. An **important** consideration when returning a request or response from this hook is that all the following hooks will be skipped, so you may want to only return them from the last hook.
 
 ###### hooks.beforeRetry
 
 Type: `Function[]`<br>
 Default: `[]`
 
-This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized input and options, an error instance and the retry count as arguments. You could, for example, modify `options.headers` here.
+This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized request and options, an error instance and the retry count as arguments. You could, for example, modify `request.headers` here.
 
 ```js
 import ky from 'ky';
@@ -242,9 +242,9 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			beforeRetry: [
-				async (input, options, errors, retryCount) => {
+				async (request, options, errors, retryCount) => {
 					const token = await ky('https://example.com/refresh-token');
-					options.headers.set('Authorization', `token ${token}`);
+					request.headers.set('Authorization', `token ${token}`);
 				}
 			]
 		}
@@ -257,7 +257,7 @@ import ky from 'ky';
 Type: `Function[]`<br>
 Default: `[]`
 
-This hook enables you to read and optionally modify the response. The hook function receives normalized input, options, and a clone of the response as arguments. The return value of the hook function will be used by Ky as the response object if it's an instance of [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
+This hook enables you to read and optionally modify the response. The hook function receives normalized request, options, and a clone of the response as arguments. The return value of the hook function will be used by Ky as the response object if it's an instance of [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
 ```js
 import ky from 'ky';
@@ -266,7 +266,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			afterResponse: [
-				(_input, _options, response) => {
+				(request, options, response) => {
 					// You could do something with the response, for example, logging.
 					log(response);
 
@@ -275,15 +275,15 @@ import ky from 'ky';
 				},
 
 				// Or retry with a fresh token on a 403 error
-				async (input, options, response) => {
+				async (request, options, response) => {
 					if (response.status === 403) {
 						// Get a fresh token
 						const token = await ky('https://example.com/token').text();
 
 						// Retry with the token
-						options.headers.set('Authorization', `token ${token}`);
+						request.headers.set('Authorization', `token ${token}`);
 
-						return ky(input, options);
+						return ky(request);
 					}
 				}
 			]

--- a/readme.md
+++ b/readme.md
@@ -226,7 +226,26 @@ Default: `[]`
 
 This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives `request` and `options` as arguments. You could, for example, modify the `request.headers` here.
 
-The hook can return a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) to replace the outgoing request, or return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) to completely avoid making an HTTP request. This can be used to mock a request, check an internal cache, etc. An **important** consideration when returning a request or response from this hook is that all the following hooks will be skipped, so you may want to only return them from the last hook.
+The hook can return a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) to replace the outgoing request, or return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) to completely avoid making an HTTP request. This can be used to mock a request, check an internal cache, etc. An **important** consideration when returning a request or response from this hook is that any remaining `beforeRequest` hooks will be skipped, so you may want to only return them from the last hook.
+
+```js
+import ky from 'ky';
+
+const api = ky.extend({
+	hooks: {
+		beforeRequest: [
+			(request) => {
+				request.headers.set('X-Requested-With', 'ky');
+			}
+		]
+	}
+});
+
+(async () => {
+	const users = await api.get('https://example.com/api/users');
+	// ...
+})();
+```
 
 ###### hooks.beforeRetry
 

--- a/readme.md
+++ b/readme.md
@@ -234,7 +234,7 @@ import ky from 'ky';
 const api = ky.extend({
 	hooks: {
 		beforeRequest: [
-			(request) => {
+			request => {
 				request.headers.set('X-Requested-With', 'ky');
 			}
 		]
@@ -285,7 +285,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			afterResponse: [
-				(request, options, response) => {
+				(_request, _options, response) => {
 					// You could do something with the response, for example, logging.
 					log(response);
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -23,11 +23,11 @@ test('hooks can be async', async t => {
 			json,
 			hooks: {
 				beforeRequest: [
-					async (_input, options) => {
+					async (request, options) => {
 						await delay(100);
 						const bodyJson = JSON.parse(options.body);
 						bodyJson.foo = false;
-						options.body = JSON.stringify(bodyJson);
+						return new Request(request, {body: JSON.stringify(bodyJson)});
 					}
 				]
 			}
@@ -70,10 +70,10 @@ test('beforeRequest hook allows modifications', async t => {
 			json,
 			hooks: {
 				beforeRequest: [
-					(_input, options) => {
+					(request, options) => {
 						const bodyJson = JSON.parse(options.body);
 						bodyJson.foo = false;
-						options.body = JSON.stringify(bodyJson);
+						return new Request(request, {body: JSON.stringify(bodyJson)});
 					}
 				]
 			}
@@ -337,8 +337,8 @@ test('beforeRetry hook allows modifications of non initial requests', async t =>
 			.get(server.url, {
 				hooks: {
 					beforeRetry: [
-						(_input, options) => {
-							options.headers.set('unicorn', fixture);
+						request => {
+							request.headers.set('unicorn', fixture);
 						}
 					]
 				}

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -246,7 +246,7 @@ test('`afterResponse` hook gets called even if using body shortcuts', async t =>
 	await server.close();
 });
 
-test.failing('`afterResponse` hook is called with input, normalized options, and response which can be used to retry', async t => {
+test('`afterResponse` hook is called with input, normalized options, and response which can be used to retry', async t => {
 	const server = await createTestServer();
 	server.post('/', async (request, response) => {
 		const body = await pBody(request);
@@ -269,10 +269,10 @@ test.failing('`afterResponse` hook is called with input, normalized options, and
 			json,
 			hooks: {
 				afterResponse: [
-					async (input, options, response) => {
+					async (request, options, response) => {
 						if (response.status === 403) {
 							// Retry request with valid token
-							return ky(input, {
+							return ky(request, {
 								...options,
 								body: JSON.stringify({
 									...JSON.parse(options.body),

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -246,7 +246,7 @@ test('`afterResponse` hook gets called even if using body shortcuts', async t =>
 	await server.close();
 });
 
-test('`afterResponse` hook is called with input, normalized options, and response which can be used to retry', async t => {
+test('`afterResponse` hook is called with request, normalized options, and response which can be used to retry', async t => {
 	const server = await createTestServer();
 	server.post('/', async (request, response) => {
 		const body = await pBody(request);

--- a/test/main.js
+++ b/test/main.js
@@ -108,9 +108,27 @@ test('POST JSON', async t => {
 	await server.close();
 });
 
+test('cannot use `body` option with GET or HEAD method', t => {
+	t.throws(() => {
+		ky.get('https://example.com', {body: 'foobar'});
+	}, 'Request with GET/HEAD method cannot have body');
+	t.throws(() => {
+		ky.head('https://example.com', {body: 'foobar'});
+	}, 'Request with GET/HEAD method cannot have body');
+});
+
+test('cannot use `json` option with GET or HEAD method', t => {
+	t.throws(() => {
+		ky.get('https://example.com', {json: {}});
+	}, 'Request with GET/HEAD method cannot have body');
+	t.throws(() => {
+		ky.head('https://example.com', {json: {}});
+	}, 'Request with GET/HEAD method cannot have body');
+});
+
 test('cannot use `json` option along with the `body` option', t => {
 	t.throws(() => {
-		ky('https://example.com', {json: {foo: 'bar'}, body: 'foobar'});
+		ky.post('https://example.com', {json: {foo: 'bar'}, body: 'foobar'});
 	}, 'The `json` option cannot be used with the `body` option');
 });
 

--- a/test/prefix-url.js
+++ b/test/prefix-url.js
@@ -5,11 +5,6 @@ import ky from '..';
 test('prefixUrl option', async t => {
 	const server = await createTestServer();
 	server.get('/', (request, response) => {
-		if (request.query.page === '/https://cat.com/') {
-			response.end('meow');
-			return;
-		}
-
 		response.end('zebra');
 	});
 	server.get('/api/unicorn', (request, response) => {
@@ -18,14 +13,15 @@ test('prefixUrl option', async t => {
 
 	t.is(await ky(`${server.url}/api/unicorn`, {prefixUrl: false}).text(), 'rainbow');
 	t.is(await ky(`${server.url}/api/unicorn`, {prefixUrl: ''}).text(), 'rainbow');
+	t.is(await ky(new URL(`${server.url}/api/unicorn`), {prefixUrl: ''}).text(), 'rainbow');
 	t.is(await ky('api/unicorn', {prefixUrl: server.url}).text(), 'rainbow');
+	t.is(await ky('api/unicorn', {prefixUrl: new URL(server.url)}).text(), 'rainbow');
 	t.is(await ky('unicorn', {prefixUrl: `${server.url}/api`}).text(), 'rainbow');
 	t.is(await ky('unicorn', {prefixUrl: `${server.url}/api/`}).text(), 'rainbow');
+	t.is(await ky('unicorn', {prefixUrl: new URL(`${server.url}/api`)}).text(), 'rainbow');
 	t.is(await ky('', {prefixUrl: server.url}).text(), 'zebra');
 	t.is(await ky('', {prefixUrl: `${server.url}/`}).text(), 'zebra');
-	t.is(await ky('https://cat.com/', {prefixUrl: new URL(`${server.url}/?page=`)}).text(), 'meow');
-	t.is(await ky(new URL('https://cat.com'), {prefixUrl: `${server.url}/?page=`}).text(), 'meow');
-	t.is(await ky(new URL('https://cat.com'), {prefixUrl: new URL(`${server.url}/?page=`)}).text(), 'meow');
+	t.is(await ky('', {prefixUrl: new URL(server.url)}).text(), 'zebra');
 
 	t.throws(() => {
 		ky('/unicorn', {prefixUrl: `${server.url}/api`});


### PR DESCRIPTION
Closes #166
Closes #139

This PR:
 - Aims to simplify Ky and solve some edge case issues and confusing behavior related to how our options are normalized and merged.
 - Makes it so that internally, and within hooks, a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) instance is now used as the source of truth instead of `input`. This replaces some of the bespoke logic that we've had for processing options. It also makes life easier for people using the `hooks` option, because they will receive a normalized `request`, whose behavior is more obvious and is well-specified by web standards. We can discuss whether the raw input should be available as well.
 - Cleans up the separation betwen Ky options and `fetch` options internally, so there's a clear distinction and it's easy to pass around one or the other, or both.
 - Adds the ability for `beforeRequest` hooks to return a `Request` instance to replace the existing request.