### PR TITLE
Pass all Ky options to hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,21 +126,21 @@ export interface RetryOptions {
 
 	@default ['get', 'put', 'head', 'delete', 'options', 'trace']
 	*/
-	methods?: string[] | Set<string>;
+	methods?: string[];
 
 	/**
 	The HTTP status codes allowed to retry.
 
 	@default [408, 413, 429, 500, 502, 503, 504]
 	*/
-	statusCodes?: number[] | Set<number>;
+	statusCodes?: number[];
 
 	/**
 	The HTTP status codes allowed to retry with a `Retry-After` header.
 
 	@default [413, 429, 503]
 	*/
-	afterStatusCodes?: number[] | Set<number>;
+	afterStatusCodes?: number[];
 
 	/**
 	If the `Retry-After` header is greater than `maxRetryAfter`, the request will be canceled.

--- a/index.d.ts
+++ b/index.d.ts
@@ -126,21 +126,21 @@ export interface RetryOptions {
 
 	@default ['get', 'put', 'head', 'delete', 'options', 'trace']
 	*/
-	methods?: string[];
+	methods?: string[] | Set<string>;
 
 	/**
 	The HTTP status codes allowed to retry.
 
 	@default [408, 413, 429, 500, 502, 503, 504]
 	*/
-	statusCodes?: number[];
+	statusCodes?: number[] | Set<number>;
 
 	/**
 	The HTTP status codes allowed to retry with a `Retry-After` header.
 
 	@default [413, 429, 503]
 	*/
-	afterStatusCodes?: number[];
+	afterStatusCodes?: number[] | Set<number>;
 
 	/**
 	If the `Retry-After` header is greater than `maxRetryAfter`, the request will be canceled.
@@ -169,11 +169,11 @@ export interface Options extends RequestInit {
 	json?: unknown;
 
 	/**
-	Search parameters to include in the request URL.
+	Search parameters to include in the request URL. Setting this will override all existing search parameters in the input URL.
 
-	Setting this will override all existing search parameters in the input URL.
+	Accepts any value supported by [`URLSearchParams()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams).
 	*/
-	searchParams?: string | {[key: string]: string | number} | URLSearchParams;
+	searchParams?: string | {[key: string]: string | number | boolean} | Array<Array<string | number | boolean>> | URLSearchParams;
 
 	/**
 	When specified, `prefixUrl` will be prepended to `input`. The prefix can be any valid URL, either relative or absolute. A trailing slash `/` is optional, one will be added automatically, if needed, when joining `prefixUrl` and `input`. The `input` argument cannot start with a `/` when using this option.

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ const globals = {};
 	};
 
 	const globalProperties = [
-		'document',
 		'Headers',
 		'Request',
 		'Response',
@@ -274,7 +273,7 @@ class Ky {
 		this.request = new globals.Request(this._input, this._fetchOptions);
 
 		if (searchParams) {
-			const url = new URL(this._input.url || this._input, globals.document && globals.document.baseURI);
+			const url = new URL(this.request.url);
 			url.search = new URLSearchParams(searchParams);
 			this.request = new globals.Request(url, this.request);
 		}

--- a/index.js
+++ b/index.js
@@ -275,14 +275,7 @@ class Ky {
 
 		if (searchParams) {
 			const url = new URL(this._input.url || this._input, globals.document && globals.document.baseURI);
-			if (typeof searchParams === 'string' || (URLSearchParams && searchParams instanceof URLSearchParams)) {
-				url.search = searchParams;
-			} else if (Object.values(searchParams).every(param => typeof param === 'number' || typeof param === 'string')) {
-				url.search = new URLSearchParams(searchParams).toString();
-			} else {
-				throw new Error('The `searchParams` option must be either a string, `URLSearchParams` instance or an object with string and number values');
-			}
-
+			url.search = new URLSearchParams(searchParams);
 			this.request = new globals.Request(url, this.request);
 		}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -133,16 +133,9 @@ ky(url, {
 // `retry` option
 ky(url, {retry: 100});
 ky(url, {
-	retry : {
+	retry: {
 		methods: [],
 		statusCodes: [],
 		afterStatusCodes: []
-	}
-});
-ky(url, {
-	retry : {
-		methods: new Set(),
-		statusCodes: new Set(),
-		afterStatusCodes: new Set()
 	}
 });

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -99,6 +99,10 @@ customKy(input, options);
 ky(url, {searchParams: 'foo=bar'});
 ky(url, {searchParams: {foo: 'bar'}});
 ky(url, {searchParams: {foo: 1}});
+ky(url, {searchParams: {foo: true}});
+ky(url, {searchParams: [['foo', 'bar']]});
+ky(url, {searchParams: [['foo', 1]]});
+ky(url, {searchParams: [['foo', true]]});
 ky(url, {searchParams: new URLSearchParams({foo: 'bar'})});
 
 // `json` option
@@ -123,5 +127,22 @@ ky(url, {
 	onDownloadProgress: (progress, chunk) => {
 		expectType<DownloadProgress>(progress);
 		expectType<Uint8Array>(chunk);
+	}
+});
+
+// `retry` option
+ky(url, {retry: 100});
+ky(url, {
+	retry : {
+		methods: [],
+		statusCodes: [],
+		afterStatusCodes: []
+	}
+});
+ky(url, {
+	retry : {
+		methods: new Set(),
+		statusCodes: new Set(),
+		afterStatusCodes: new Set()
 	}
 });

--- a/readme.md
+++ b/readme.md
@@ -145,10 +145,12 @@ Shortcut for sending JSON. Use this instead of the `body` option. Accepts a plai
 
 ##### searchParams
 
-Type: `string | object<string, string | number> | URLSearchParams`<br>
+Type: `string | object<string, string | number | boolean> | Array<Array<string | number | boolean>> | URLSearchParams`<br>
 Default: `''`
 
 Search parameters to include in the request URL. Setting this will override all existing search parameters in the input URL.
+
+Accepts any value supported by [`URLSearchParams()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams).
 
 ##### prefixUrl
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -274,10 +274,10 @@ test('`afterResponse` hook is called with request, normalized options, and respo
 							// Retry request with valid token
 							return ky(request, {
 								...options,
-								body: JSON.stringify({
-									...JSON.parse(options.body),
+								json: {
+									...options.json,
 									token: 'valid:token'
-								})
+								}
 							});
 						}
 					}

--- a/test/main.js
+++ b/test/main.js
@@ -126,10 +126,27 @@ test('cannot use `json` option with GET or HEAD method', t => {
 	}, 'Request with GET/HEAD method cannot have body');
 });
 
-test('cannot use `json` option along with the `body` option', t => {
-	t.throws(() => {
-		ky.post('https://example.com', {json: {foo: 'bar'}, body: 'foobar'});
-	}, 'The `json` option cannot be used with the `body` option');
+test('`json` option overrides the `body` option', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.post('/', async (request, response) => {
+		t.is(request.headers['content-type'], 'application/json');
+		response.json(JSON.parse(await pBody(request)));
+	});
+
+	const json = {
+		foo: 'bar'
+	};
+
+	const responseJson = await ky.post(server.url, {
+		body: 'hello',
+		json
+	}).json();
+
+	t.deepEqual(json, responseJson);
+
+	await server.close();
 });
 
 test('custom headers', async t => {

--- a/test/main.js
+++ b/test/main.js
@@ -244,24 +244,19 @@ test('searchParams option', async t => {
 		response.end(request.url.slice(1));
 	});
 
-	const stringParams = '?pass=true';
-	const objectParams = {pass: 'true'};
-	const searchParams = new URLSearchParams(stringParams);
+	const arrayParams = [['cats', 'meow'], ['dogs', true], ['opossums', false]];
+	const objectParams = {
+		cats: 'meow',
+		dogs: true,
+		opossums: false
+	};
+	const searchParams = new URLSearchParams(arrayParams);
+	const stringParams = '?cats=meow&dogs=true&opossums=false';
 
-	t.is(await ky(server.url, {searchParams: stringParams}).text(), stringParams);
+	t.is(await ky(server.url, {searchParams: arrayParams}).text(), stringParams);
 	t.is(await ky(server.url, {searchParams: objectParams}).text(), stringParams);
 	t.is(await ky(server.url, {searchParams}).text(), stringParams);
-
-	t.throws(() => {
-		ky(server.url, {
-			searchParams: {
-				pass: [
-					'true',
-					'false'
-				]
-			}
-		});
-	}, /`searchParams` option must be/);
+	t.is(await ky(server.url, {searchParams: stringParams}).text(), stringParams);
 
 	await server.close();
 });

--- a/test/retry.js
+++ b/test/retry.js
@@ -315,6 +315,27 @@ test('does retry on 408 with methods provided as array', async t => {
 	await server.close();
 });
 
+test('does retry on 408 with methods provided as a Set', async t => {
+	let requestCount = 0;
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		requestCount++;
+		response.sendStatus(408);
+	});
+
+	await t.throwsAsync(ky(server.url, {
+		retry: {
+			limit: 4,
+			methods: new Set(['get'])
+		}
+	}).text());
+
+	t.is(requestCount, 4);
+
+	await server.close();
+});
+
 test('does retry on 408 with statusCodes provided as array', async t => {
 	let requestCount = 0;
 
@@ -328,6 +349,27 @@ test('does retry on 408 with statusCodes provided as array', async t => {
 		retry: {
 			limit: 4,
 			statusCodes: [408]
+		}
+	}).text());
+
+	t.is(requestCount, 4);
+
+	await server.close();
+});
+
+test('does retry on 408 with statusCodes provided as a Set', async t => {
+	let requestCount = 0;
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		requestCount++;
+		response.sendStatus(408);
+	});
+
+	await t.throwsAsync(ky(server.url, {
+		retry: {
+			limit: 4,
+			statusCodes: new Set([408])
 		}
 	}).text());
 
@@ -356,13 +398,13 @@ test('doesn\'t retry when retry.limit is set to 0', async t => {
 	await server.close();
 });
 
-test('throws when retry.methods is not an array', async t => {
+test('throws when retry.methods is not an array or Set', async t => {
 	const server = await createTestServer();
 
 	t.throws(() => {
 		ky(server.url, {
 			retry: {
-				methods: new Set(['get'])
+				methods: 'get'
 			}
 		});
 	});
@@ -370,13 +412,13 @@ test('throws when retry.methods is not an array', async t => {
 	await server.close();
 });
 
-test('throws when retry.statusCodes is not an array', async t => {
+test('throws when retry.statusCodes is not an array or Set', async t => {
 	const server = await createTestServer();
 
 	t.throws(() => {
 		ky(server.url, {
 			retry: {
-				statusCodes: new Set([403])
+				statusCodes: 403
 			}
 		});
 	});

--- a/test/retry.js
+++ b/test/retry.js
@@ -315,27 +315,6 @@ test('does retry on 408 with methods provided as array', async t => {
 	await server.close();
 });
 
-test('does retry on 408 with methods provided as a Set', async t => {
-	let requestCount = 0;
-
-	const server = await createTestServer();
-	server.get('/', async (request, response) => {
-		requestCount++;
-		response.sendStatus(408);
-	});
-
-	await t.throwsAsync(ky(server.url, {
-		retry: {
-			limit: 4,
-			methods: new Set(['get'])
-		}
-	}).text());
-
-	t.is(requestCount, 4);
-
-	await server.close();
-});
-
 test('does retry on 408 with statusCodes provided as array', async t => {
 	let requestCount = 0;
 
@@ -349,27 +328,6 @@ test('does retry on 408 with statusCodes provided as array', async t => {
 		retry: {
 			limit: 4,
 			statusCodes: [408]
-		}
-	}).text());
-
-	t.is(requestCount, 4);
-
-	await server.close();
-});
-
-test('does retry on 408 with statusCodes provided as a Set', async t => {
-	let requestCount = 0;
-
-	const server = await createTestServer();
-	server.get('/', async (request, response) => {
-		requestCount++;
-		response.sendStatus(408);
-	});
-
-	await t.throwsAsync(ky(server.url, {
-		retry: {
-			limit: 4,
-			statusCodes: new Set([408])
 		}
 	}).text());
 
@@ -398,7 +356,7 @@ test('doesn\'t retry when retry.limit is set to 0', async t => {
 	await server.close();
 });
 
-test('throws when retry.methods is not an array or Set', async t => {
+test('throws when retry.methods is not an array', async t => {
 	const server = await createTestServer();
 
 	t.throws(() => {
@@ -412,7 +370,7 @@ test('throws when retry.methods is not an array or Set', async t => {
 	await server.close();
 });
 
-test('throws when retry.statusCodes is not an array or Set', async t => {
+test('throws when retry.statusCodes is not an array', async t => {
 	const server = await createTestServer();
 
 	t.throws(() => {


### PR DESCRIPTION
Closes #167
Closes #182
Closes #187

This PR:
 - Updates the `options` object passed to hooks so that _all_ Ky and fetch options are included. For context: in Ky v0.15.0 and earlier, a subset of Ky options were included in the `options` object (e.g. `prefixUrl` was included, but `throwHttpErrors` was not, without any clear justification).
 - Loosens the validation of certain options so that hooks can pass their options (which are already _normalized_) to Ky to make a new request using the same options. For example, the `json` option now takes precedence over `body`, rather than being mutually exclusive with `body`. Additionally, `searchParams` can now be any value supported by [`URLSearchParams()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams), which makes it possible to use a boolean as a param value, provide the params as an array of entries, etc.
 - Removes our reliance on the [`document`](https://developer.mozilla.org/en-US/docs/Web/API/Document) object, which was previously used in some circumstances to determine the base URL of the page, from which we resolve relative URLs. The [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) class is now used to achieve the same goal. `Request` is significantly easier to polyfill and is much more likely to be available in web workers and non-browser environments.
 - Drops support for `Set`s throughout the API for simplicity. This should not have any meaningful performance impacts, since the lists of HTTP methods and status codes are inherently small in size, even if you were to include all valid methods and status codes. See https://github.com/sindresorhus/ky/pull/188#discussion_r340767280.