### PR TITLE
Add package.json funding property

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
+	"funding": "https://github.com/sindresorhus/ky?sponsor=1",
 	"engines": {
 		"node": ">=8"
 	},
@@ -23,10 +24,6 @@
 		"umd.js",
 		"umd.d.ts"
 	],
-	"funding": {
-		"type": "GitHub",
-		"url": "https://github.com/sponsors/sindresorhus"
-	},
 	"keywords": [
 		"fetch",
 		"request",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
 	"description": "Tiny and elegant HTTP client based on the browser Fetch API",
 	"license": "MIT",
 	"repository": "sindresorhus/ky",
+	"funding": "https://github.com/sindresorhus/ky?sponsor=1",
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
-	"funding": "https://github.com/sindresorhus/ky?sponsor=1",
 	"engines": {
 		"node": ">=8"
 	},

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
 		"umd.js",
 		"umd.d.ts"
 	],
+	"funding": {
+		"type": "GitHub",
+		"url": "https://github.com/sponsors/sindresorhus"
+	},
 	"keywords": [
 		"fetch",
 		"request",


### PR DESCRIPTION
**npm** just added a new [`npm fund` command](https://blog.npmjs.org/post/188841555980/updates-to-community-docs-more) in it's [v6.13.0](https://github.com/npm/cli/releases/tag/v6.13.0) release as part of the efforts to help out the OSS community.

This PR adds `funding` info to **ky** so that users depending on it can actually retrieve the funding url when they run `npm fund` in their projects.

Note: The funding information will only be available once a new version of the package is published to the npm registry.