### PR TITLE
Avoid body method parse errors on 204 responses

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -291,7 +291,7 @@ interface NormalizedOptions extends RequestInit {
 }
 
 /**
-Returns a `Response` object with `Body` methods added for convenience.
+Returns a `Response` object with `Body` methods added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299` and they will return `undefined` if the response status is `204` instead of throwing a parse error due to an empty body.
 */
 export interface ResponsePromise extends Promise<Response> {
 	arrayBuffer(): Promise<ArrayBuffer>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -291,7 +291,7 @@ interface NormalizedOptions extends RequestInit {
 }
 
 /**
-Returns a `Response` object with `Body` methods added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299` and they will return `undefined` if the response status is `204` instead of throwing a parse error due to an empty body.
+Returns a `Response` object with `Body` methods added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return an empty string if the response status is `204` instead of throwing a parse error due to an empty body.
 */
 export interface ResponsePromise extends Promise<Response> {
 	arrayBuffer(): Promise<ArrayBuffer>;

--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ class Ky {
 			result[type] = async () => {
 				this.request.headers.set('accept', mimeType);
 				const response = (await result).clone();
-				return response.status === 204 ? undefined : response[type]();
+				return (type === 'json' && response.status === 204) ? '' : response[type]();
 			};
 		}
 

--- a/index.js
+++ b/index.js
@@ -316,7 +316,8 @@ class Ky {
 		for (const [type, mimeType] of Object.entries(responseTypes)) {
 			result[type] = async () => {
 				this.request.headers.set('accept', mimeType);
-				return (await result).clone()[type]();
+				const response = (await result).clone();
+				return response.status === 204 ? undefined : response[type]();
 			};
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ The `input` and `options` are the same as [`fetch`](https://developer.mozilla.or
 - The `credentials` option is `same-origin` by default, which is the default in the spec too, but not all browsers have caught up yet.
 - Adds some more options. See below.
 
-Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, proper `Accept` header will be set depending on body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range `200...299` and they will return `undefined` if the response status is 204 instead of throwing a parse error due to an empty body.
+Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299` and they will return `undefined` if the response status is `204` instead of throwing a parse error due to an empty body.
 
 ### ky.get(input, options?)
 ### ky.post(input, options?)

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ The `input` and `options` are the same as [`fetch`](https://developer.mozilla.or
 - The `credentials` option is `same-origin` by default, which is the default in the spec too, but not all browsers have caught up yet.
 - Adds some more options. See below.
 
-Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299` and they will return `undefined` if the response status is `204` instead of throwing a parse error due to an empty body.
+Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return an empty string if the response status is `204` instead of throwing a parse error due to an empty body.
 
 ### ky.get(input, options?)
 ### ky.post(input, options?)

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ The `input` and `options` are the same as [`fetch`](https://developer.mozilla.or
 - The `credentials` option is `same-origin` by default, which is the default in the spec too, but not all browsers have caught up yet.
 - Adds some more options. See below.
 
-Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, proper `Accept` header will be set depending on body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range `200...299`.
+Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, proper `Accept` header will be set depending on body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range `200...299` and they will return `undefined` if the response status is 204 instead of throwing a parse error due to an empty body.
 
 ### ky.get(input, options?)
 ### ky.post(input, options?)

--- a/test/main.js
+++ b/test/main.js
@@ -188,7 +188,7 @@ test('JSON with custom Headers instance', async t => {
 	await server.close();
 });
 
-test('JSON with 200 response and empty body', async t => {
+test('.json() with 200 response and empty body', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
@@ -202,7 +202,7 @@ test('JSON with 200 response and empty body', async t => {
 	await server.close();
 });
 
-test('JSON with 204 response and empty body', async t => {
+test('.json() with 204 response and empty body', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
@@ -213,7 +213,7 @@ test('JSON with 204 response and empty body', async t => {
 
 	const responseJson = await ky(server.url).json();
 
-	t.is(responseJson, undefined);
+	t.is(responseJson, '');
 
 	await server.close();
 });

--- a/test/main.js
+++ b/test/main.js
@@ -188,6 +188,36 @@ test('JSON with custom Headers instance', async t => {
 	await server.close();
 });
 
+test('JSON with 200 response and empty body', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		t.is(request.headers['accept'], 'application/json');
+		response.status(200).end();
+	});
+
+	await t.throwsAsync(ky(server.url).json(), /Unexpected end of JSON input/);
+
+	await server.close();
+});
+
+test('JSON with 204 response and empty body', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		t.is(request.headers['accept'], 'application/json');
+		response.status(204).end();
+	});
+
+	const responseJson = await ky(server.url).json();
+
+	t.is(responseJson, undefined);
+
+	await server.close();
+});
+
 test('timeout option', async t => {
 	let requestCount = 0;
 

--- a/test/main.js
+++ b/test/main.js
@@ -193,7 +193,7 @@ test('JSON with 200 response and empty body', async t => {
 
 	const server = await createTestServer();
 	server.get('/', async (request, response) => {
-		t.is(request.headers['accept'], 'application/json');
+		t.is(request.headers.accept, 'application/json');
 		response.status(200).end();
 	});
 
@@ -207,7 +207,7 @@ test('JSON with 204 response and empty body', async t => {
 
 	const server = await createTestServer();
 	server.get('/', async (request, response) => {
-		t.is(request.headers['accept'], 'application/json');
+		t.is(request.headers.accept, 'application/json');
 		response.status(204).end();
 	});
 


### PR DESCRIPTION
Closes #193

This PR short-circuits the `.json()` body method and makes it return an empty string instead of parsing the body when the response status is 204 No Content. That way we avoid throwing a parse error due to an empty body.

Note that, as of this writing, we make no attempt to read the response body to check if it is empty, rather we trust the response status code from the server.