### PR TITLE
Add ability to stop retries in `beforeRetry` hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -342,7 +342,7 @@ export class TimeoutError extends Error {
 /**
 Symbol for aborting retries in the `beforeRetry` hook
 */
-export const NO_RETRY_SYMBOL: Symbol;
+export const ABANDON_RETRY: Symbol;
 
 declare const ky: {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -339,6 +339,11 @@ export class TimeoutError extends Error {
 	constructor();
 }
 
+/**
+Symbol for aborting retries in the `beforeRetry` hook
+*/
+export const NO_RETRY_SYMBOL: Symbol;
+
 declare const ky: {
 	/**
 	Fetch the given `url`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -340,9 +340,9 @@ export class TimeoutError extends Error {
 }
 
 /**
-Symbol for aborting retries in the `beforeRetry` hook
+Symbol for aborting retries in the `beforeRetry` hook.
 */
-export const ABANDON_RETRY: Symbol;
+declare const stop: unique symbol;
 
 declare const ky: {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -339,32 +339,6 @@ export class TimeoutError extends Error {
 	constructor();
 }
 
-/**
-A `Symbol` that can be returned by a `beforeRetry` hook to stop the retry.
-This will also short circuit the remaining `beforeRetry` hooks.
-
-@example
-```
-import ky, {stop as kyStop} from 'ky';
-
-(async () => {
-	await ky('https://example.com', {
-		hooks: {
-			beforeRetry: [
-				async (request, options, errors, retryCount) => {
-					const shouldStopRetry = await ky('https://example.com/api');
-					if (shouldStopRetry) {
-						return kyStop;
-					}
-				}
-			]
-		}
-	});
-})();
-```
-*/
-export const stop: unique symbol;
-
 declare const ky: {
 	/**
 	Fetch the given `url`.
@@ -449,6 +423,32 @@ declare const ky: {
 	@returns A new Ky instance.
 	*/
 	extend(defaultOptions: Options): typeof ky;
+
+	/**
+	A `Symbol` that can be returned by a `beforeRetry` hook to stop the retry.
+	This will also short circuit the remaining `beforeRetry` hooks.
+
+	@example
+	```
+	import ky from 'ky';
+
+	(async () => {
+		await ky('https://example.com', {
+			hooks: {
+				beforeRetry: [
+					async (request, options, errors, retryCount) => {
+						const shouldStopRetry = await ky('https://example.com/api');
+						if (shouldStopRetry) {
+							return ky.stop;
+						}
+					}
+				]
+			}
+		});
+	})();
+	```
+	*/
+	readonly stop: unique symbol;
 };
 
 export default ky;

--- a/index.d.ts
+++ b/index.d.ts
@@ -342,7 +342,7 @@ export class TimeoutError extends Error {
 /**
 Symbol for aborting retries in the `beforeRetry` hook.
 */
-declare const stop: unique symbol;
+export const stop: unique symbol;
 
 declare const ky: {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -340,7 +340,28 @@ export class TimeoutError extends Error {
 }
 
 /**
-Symbol for aborting retries in the `beforeRetry` hook.
+A `Symbol` that can be returned by a `beforeRetry` hook to stop the retry.
+This will also short circuit the remaining `beforeRetry` hooks.
+
+@example
+```
+import ky, {stop as kyStop} from 'ky';
+
+(async () => {
+	await ky('https://example.com', {
+		hooks: {
+			beforeRetry: [
+				async (request, options, errors, retryCount) => {
+					const shouldStopRetry = await ky('https://example.com/api');
+					if (shouldStopRetry) {
+						return kyStop;
+					}
+				}
+			]
+		}
+	});
+})();
+```
 */
 export const stop: unique symbol;
 

--- a/index.js
+++ b/index.js
@@ -473,6 +473,7 @@ const createInstance = defaults => {
 
 	ky.create = newDefaults => createInstance(validateAndMerge(newDefaults));
 	ky.extend = newDefaults => createInstance(validateAndMerge(defaults, newDefaults));
+	ky.stop = stop;
 
 	return ky;
 };
@@ -481,6 +482,5 @@ export default createInstance();
 
 export {
 	HTTPError,
-	TimeoutError,
-	stop
+	TimeoutError
 };

--- a/index.js
+++ b/index.js
@@ -370,22 +370,19 @@ class Ky {
 			if (ms !== 0 && this._retryCount > 0) {
 				await delay(ms);
 
-				const beforeRetryResults = new Set();
-
 				for (const hook of this._options.hooks.beforeRetry) {
-					beforeRetryResults.add(
-						// eslint-disable-next-line no-await-in-loop
-						await hook(
-							this.request,
-							this._options,
-							error,
-							this._retryCount,
-						)
+					// eslint-disable-next-line no-await-in-loop
+					const hookResult = await hook(
+						this.request,
+						this._options,
+						error,
+						this._retryCount,
 					);
-				}
 
-				if (beforeRetryResults.has(stop)) {
-					return;
+					// If `stop` is returned from the hook, the retry process is stopped
+					if (hookResult === stop) {
+						return;
+					}
 				}
 
 				return this._retry(fn);

--- a/index.js
+++ b/index.js
@@ -45,8 +45,7 @@ const globals = {};
 		'ReadableStream',
 		'fetch',
 		'AbortController',
-		'FormData',
-		'Symbol'
+		'FormData'
 	];
 
 	const props = {};
@@ -132,7 +131,7 @@ const retryAfterStatusCodes = [
 	503
 ];
 
-const ABANDON_RETRY = globals.Symbol('abandon-retry');
+const stop = Symbol('stop');
 
 class HTTPError extends Error {
 	constructor(response) {
@@ -385,7 +384,7 @@ class Ky {
 					);
 				}
 
-				if (beforeRetryResults.has(ABANDON_RETRY)) {
+				if (beforeRetryResults.has(stop)) {
 					return;
 				}
 
@@ -486,5 +485,5 @@ export default createInstance();
 export {
 	HTTPError,
 	TimeoutError,
-	ABANDON_RETRY
+	stop
 };

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ const retryAfterStatusCodes = [
 	503
 ];
 
-const NO_RETRY_SYMBOL = globals.Symbol('no-retry');
+const ABANDON_RETRY = globals.Symbol('abandon-retry');
 
 class HTTPError extends Error {
 	constructor(response) {
@@ -385,7 +385,7 @@ class Ky {
 					);
 				}
 
-				if (beforeRetryResults.has(NO_RETRY_SYMBOL)) {
+				if (beforeRetryResults.has(ABANDON_RETRY)) {
 					return;
 				}
 
@@ -486,5 +486,5 @@ export default createInstance();
 export {
 	HTTPError,
 	TimeoutError,
-	NO_RETRY_SYMBOL
+	ABANDON_RETRY
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input} from '.';
+import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input, NO_RETRY_SYMBOL} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -25,6 +25,7 @@ expectType<typeof ky>(ky.create({}));
 expectType<typeof ky>(ky.extend({}));
 expectType<HTTPError>(new HTTPError(new Response));
 expectType<TimeoutError>(new TimeoutError);
+expectType<Symbol>(NO_RETRY_SYMBOL);
 
 ky(url, {
 	hooks: {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input, stop} from '.';
+import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -25,7 +25,7 @@ expectType<typeof ky>(ky.create({}));
 expectType<typeof ky>(ky.extend({}));
 expectType<HTTPError>(new HTTPError(new Response));
 expectType<TimeoutError>(new TimeoutError);
-expectType<symbol>(stop);
+expectType<symbol>(ky.stop);
 
 ky(url, {
 	hooks: {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input, ABANDON_RETRY} from '.';
+import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input, stop} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -25,7 +25,7 @@ expectType<typeof ky>(ky.create({}));
 expectType<typeof ky>(ky.extend({}));
 expectType<HTTPError>(new HTTPError(new Response));
 expectType<TimeoutError>(new TimeoutError);
-expectType<Symbol>(ABANDON_RETRY);
+expectType<Symbol>(stop);
 
 ky(url, {
 	hooks: {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input, NO_RETRY_SYMBOL} from '.';
+import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, Input, ABANDON_RETRY} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -25,7 +25,7 @@ expectType<typeof ky>(ky.create({}));
 expectType<typeof ky>(ky.extend({}));
 expectType<HTTPError>(new HTTPError(new Response));
 expectType<TimeoutError>(new TimeoutError);
-expectType<Symbol>(NO_RETRY_SYMBOL);
+expectType<Symbol>(ABANDON_RETRY);
 
 ky(url, {
 	hooks: {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -25,7 +25,7 @@ expectType<typeof ky>(ky.create({}));
 expectType<typeof ky>(ky.extend({}));
 expectType<HTTPError>(new HTTPError(new Response));
 expectType<TimeoutError>(new TimeoutError);
-expectType<Symbol>(stop);
+expectType<symbol>(stop);
 
 ky(url, {
 	hooks: {

--- a/readme.md
+++ b/readme.md
@@ -390,7 +390,7 @@ The error thrown when the request times out.
 A `Symbol` that can be returned by a `beforeRetry` hook to stop the retry. This will also short circuit the remaining `beforeRetry` hooks.
 
 ```js
-import ky, {stop as kyStop} from 'ky';
+import ky from 'ky';
 
 (async () => {
 	await ky('https://example.com', {
@@ -399,7 +399,7 @@ import ky, {stop as kyStop} from 'ky';
 				async (request, options, errors, retryCount) => {
 					const shouldStopRetry = await ky('https://example.com/api');
 					if (shouldStopRetry) {
-						return kyStop;
+						return ky.stop;
 					}
 				}
 			]

--- a/readme.md
+++ b/readme.md
@@ -385,6 +385,26 @@ Exposed for `instanceof` checks. The error has a `response` property with the [`
 
 The error thrown when the request times out.
 
+### ky.stop
+
+A Symbol that can be returned by a `beforeRetry` hook to stop the retry. This will also short circuit the remaining `beforeRetry` hooks.
+
+```js
+import ky, {stop} from 'ky';
+
+(async () => {
+	await ky('https://example.com', {
+		hooks: {
+			beforeRetry: [
+				async (request, options, errors, retryCount) => {
+					const stopRetry = await ky('https://example.com/api');
+					if (stopRetry) return stop;
+				}
+			]
+		}
+	});
+})();
+```
 
 ## Tips
 

--- a/readme.md
+++ b/readme.md
@@ -387,7 +387,7 @@ The error thrown when the request times out.
 
 ### ky.stop
 
-A Symbol that can be returned by a `beforeRetry` hook to stop the retry. This will also short circuit the remaining `beforeRetry` hooks.
+A `Symbol` that can be returned by a `beforeRetry` hook to stop the retry. This will also short circuit the remaining `beforeRetry` hooks.
 
 ```js
 import ky, {stop} from 'ky';
@@ -397,14 +397,17 @@ import ky, {stop} from 'ky';
 		hooks: {
 			beforeRetry: [
 				async (request, options, errors, retryCount) => {
-					const stopRetry = await ky('https://example.com/api');
-					if (stopRetry) return stop;
+					const shouldStopRetry = await ky('https://example.com/api');
+					if (shouldStopRetry) {
+						return stop;
+					}
 				}
 			]
 		}
 	});
 })();
 ```
+
 
 ## Tips
 

--- a/readme.md
+++ b/readme.md
@@ -390,7 +390,7 @@ The error thrown when the request times out.
 A `Symbol` that can be returned by a `beforeRetry` hook to stop the retry. This will also short circuit the remaining `beforeRetry` hooks.
 
 ```js
-import ky, {stop} from 'ky';
+import ky, {stop as kyStop} from 'ky';
 
 (async () => {
 	await ky('https://example.com', {
@@ -399,7 +399,7 @@ import ky, {stop} from 'ky';
 				async (request, options, errors, retryCount) => {
 					const shouldStopRetry = await ky('https://example.com/api');
 					if (shouldStopRetry) {
-						return stop;
+						return kyStop;
 					}
 				}
 			]

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -3,7 +3,7 @@ import test from 'ava';
 import createTestServer from 'create-test-server';
 import body from 'body';
 import delay from 'delay';
-import ky, {NO_RETRY_SYMBOL} from '..';
+import ky, {ABANDON_RETRY} from '..';
 
 const pBody = util.promisify(body);
 
@@ -378,7 +378,7 @@ test('beforeRetry hook is called with error and retryCount', async t => {
 	await server.close();
 });
 
-test('beforeRetry hook can cancel retries by returning NO_RETRY_SYMBOL', async t => {
+test('beforeRetry hook can cancel retries by returning ABANDON_RETRY', async t => {
 	let requestCount = 0;
 
 	const server = await createTestServer();
@@ -399,7 +399,7 @@ test('beforeRetry hook can cancel retries by returning NO_RETRY_SYMBOL', async t
 					t.truthy(error);
 					t.true(retryCount === 1);
 
-					return NO_RETRY_SYMBOL;
+					return ABANDON_RETRY;
 				}
 			]
 		}

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -3,7 +3,7 @@ import test from 'ava';
 import createTestServer from 'create-test-server';
 import body from 'body';
 import delay from 'delay';
-import ky, {stop} from '..';
+import ky from '..';
 
 const pBody = util.promisify(body);
 
@@ -399,7 +399,7 @@ test('beforeRetry hook can cancel retries by returning `stop`', async t => {
 					t.truthy(error);
 					t.is(retryCount, 1);
 
-					return stop;
+					return ky.stop;
 				}
 			]
 		}

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -3,7 +3,7 @@ import test from 'ava';
 import createTestServer from 'create-test-server';
 import body from 'body';
 import delay from 'delay';
-import ky, {ABANDON_RETRY} from '..';
+import ky, {stop} from '..';
 
 const pBody = util.promisify(body);
 
@@ -378,7 +378,7 @@ test('beforeRetry hook is called with error and retryCount', async t => {
 	await server.close();
 });
 
-test('beforeRetry hook can cancel retries by returning ABANDON_RETRY', async t => {
+test('beforeRetry hook can cancel retries by returning `stop`', async t => {
 	let requestCount = 0;
 
 	const server = await createTestServer();
@@ -397,15 +397,15 @@ test('beforeRetry hook can cancel retries by returning ABANDON_RETRY', async t =
 			beforeRetry: [
 				(_input, options, error, retryCount) => {
 					t.truthy(error);
-					t.true(retryCount === 1);
+					t.is(retryCount, 1);
 
-					return ABANDON_RETRY;
+					return stop;
 				}
 			]
 		}
 	});
 
-	t.true(requestCount === 1);
+	t.is(requestCount, 1);
 
 	await server.close();
 });


### PR DESCRIPTION
Hello,

This is related to the discussion from #185.

Summary of the PR:

- exported a new Symbol `NO_RETRY_SYMBOL`
- the Symbol can be imported & returned from a `beforeRetry` hook in order to abandon retries
- I'm unsure if an error should be thrown even if you have `throwHttpErrors` enabled
- added test & tsd

@sholladay @sindresorhus 
Thoughts?

Thank you!