### PR TITLE
Allow overriding the default accept headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,7 +315,7 @@ class Ky {
 
 		for (const [type, mimeType] of Object.entries(responseTypes)) {
 			result[type] = async () => {
-				this.request.headers.set('accept', mimeType);
+				this.request.headers.set('accept', this.request.headers.get('accept') || mimeType);
 				const response = (await result).clone();
 				return (type === 'json' && response.status === 204) ? '' : response[type]();
 			};

--- a/test/main.js
+++ b/test/main.js
@@ -188,6 +188,24 @@ test('JSON with custom Headers instance', async t => {
 	await server.close();
 });
 
+test('.json() with custom accept header', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		t.is(request.headers.accept, 'foo/bar');
+		response.json({});
+	});
+
+	const responseJson = await ky(server.url, {
+		headers: {accept: 'foo/bar'}
+	}).json();
+
+	t.deepEqual(responseJson, {});
+
+	await server.close();
+});
+
 test('.json() with 200 response and empty body', async t => {
 	t.plan(2);
 


### PR DESCRIPTION
Fixes #199 

This PR makes it possible to override the HTTP `accept` header that Ky sets by default when a [body method](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) shortcut is used, such as `.json()`.