### PR TITLE
Add `response` to `beforeRetry` hook and change its parameter to a single object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,12 +13,13 @@ export type BeforeRequestHook = (
 	options: NormalizedOptions,
 ) => Request | Response | void | Promise<Request | Response | void>;
 
-export type BeforeRetryHook = (
+export type BeforeRetryHook = (options: {
 	request: Request,
 	options: NormalizedOptions,
 	error: Error,
+	response: Response;
 	retryCount: number,
-) => void | Promise<void>;
+}) => void | Promise<void>;
 
 export type AfterResponseHook = (
 	request: Request,

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,9 +15,9 @@ export type BeforeRequestHook = (
 
 export type BeforeRetryHook = (options: {
 	request: Request,
+	response: Response,
 	options: NormalizedOptions,
 	error: Error,
-	response: Response;
 	retryCount: number,
 }) => void | Promise<void>;
 

--- a/index.js
+++ b/index.js
@@ -371,12 +371,13 @@ class Ky {
 
 				for (const hook of this._options.hooks.beforeRetry) {
 					// eslint-disable-next-line no-await-in-loop
-					await hook(
-						this.request,
-						this._options,
+					await hook({
+						request: this.request,
+						options: this._options,
 						error,
-						this._retryCount,
-					);
+						response: error.response.clone(),
+						retryCount: this._retryCount
+					});
 				}
 
 				return this._retry(fn);

--- a/index.js
+++ b/index.js
@@ -362,7 +362,7 @@ class Ky {
 						error,
 						response: error.response.clone(),
 						retryCount: this._retryCount
-          });
+					});
 
 					// If `stop` is returned from the hook, the retry process is stopped
 					if (hookResult === stop) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -48,8 +48,9 @@ ky(url, {
 			}
 		],
 		beforeRetry: [
-			(request, options, error, retryCount) => {
+			({request, options, error, retryCount, response}) => {
 				expectType<Request>(request);
+				expectType<Response>(response);
 				expectType<NormalizedOptions>(options);
 				expectType<Error>(error);
 				expectType<number>(retryCount);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -48,7 +48,7 @@ ky(url, {
 			}
 		],
 		beforeRetry: [
-			({request, options, error, retryCount, response}) => {
+			({request, response, options, error, retryCount}) => {
 				expectType<Request>(request);
 				expectType<Response>(response);
 				expectType<NormalizedOptions>(options);

--- a/readme.md
+++ b/readme.md
@@ -395,7 +395,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			beforeRetry: [
-				async ({request, options, errors, retryCount, response}) => {
+				async ({request, response, options, errors, retryCount}) => {
 					const shouldStopRetry = await ky('https://example.com/api');
 					if (shouldStopRetry) {
 						return ky.stop;

--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			beforeRetry: [
-				async (request, options, errors, retryCount) => {
+				async ({request, options, errors, retryCount, response}) => {
 					const token = await ky('https://example.com/refresh-token');
 					request.headers.set('Authorization', `token ${token}`);
 				}
@@ -395,7 +395,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			beforeRetry: [
-				async (request, options, errors, retryCount) => {
+				async ({request, options, errors, retryCount, response}) => {
 					const shouldStopRetry = await ky('https://example.com/api');
 					if (shouldStopRetry) {
 						return ky.stop;

--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			beforeRetry: [
-				async ({request, options, errors, retryCount, response}) => {
+				async ({request, response, options, errors, retryCount}) => {
 					const token = await ky('https://example.com/refresh-token');
 					request.headers.set('Authorization', `token ${token}`);
 				}

--- a/readme.md
+++ b/readme.md
@@ -253,7 +253,7 @@ const api = ky.extend({
 Type: `Function[]`\
 Default: `[]`
 
-This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized request and options, an error instance and the retry count as arguments. You could, for example, modify `request.headers` here.
+This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized request and options, the failed response, an error instance and the retry count as arguments. You could, for example, modify `request.headers` here.
 
 ```js
 import ky from 'ky';

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -304,7 +304,7 @@ test('beforeRetry hook is never called for the initial request', async t => {
 			.get(server.url, {
 				hooks: {
 					beforeRetry: [
-						(_input, options) => {
+						({options}) => {
 							options.headers.set('unicorn', fixture);
 						}
 					]
@@ -337,7 +337,7 @@ test('beforeRetry hook allows modifications of non initial requests', async t =>
 			.get(server.url, {
 				hooks: {
 					beforeRetry: [
-						request => {
+						({request}) => {
 							request.headers.set('unicorn', fixture);
 						}
 					]
@@ -367,7 +367,7 @@ test('beforeRetry hook is called with error and retryCount', async t => {
 	await ky.get(server.url, {
 		hooks: {
 			beforeRetry: [
-				(_input, options, error, retryCount) => {
+				({error, retryCount}) => {
 					t.truthy(error);
 					t.true(retryCount >= 1);
 				}
@@ -395,7 +395,7 @@ test('beforeRetry hook can cancel retries by returning `stop`', async t => {
 	await ky.get(server.url, {
 		hooks: {
 			beforeRetry: [
-				(_input, options, error, retryCount) => {
+				({error, retryCount}) => {
 					t.truthy(error);
 					t.is(retryCount, 1);
 


### PR DESCRIPTION
Fixes #194 