### PR TITLE
Fix global property lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,62 +2,43 @@
 
 const globals = {};
 
-{
-	const getGlobal = property => {
-		let parent;
-
-		/* istanbul ignore next */
-		if (typeof self !== 'undefined' && self && property in self) {
-			parent = self;
-		}
-
-		/* istanbul ignore next */
-		if (typeof window !== 'undefined' && window && property in window) {
-			parent = window;
-		}
-
-		if (typeof global !== 'undefined' && global && property in global) {
-			parent = global;
-		}
-
-		/* istanbul ignore next */
-		if (typeof globalThis !== 'undefined' && globalThis) {
-			parent = globalThis;
-		}
-
-		if (typeof parent === 'undefined') {
-			return;
-		}
-
-		const globalProperty = parent[property];
-
-		if (typeof globalProperty === 'function') {
-			return globalProperty.bind(parent);
-		}
-
-		return globalProperty;
-	};
-
-	const globalProperties = [
-		'Headers',
-		'Request',
-		'Response',
-		'ReadableStream',
-		'fetch',
-		'AbortController',
-		'FormData'
-	];
-
-	const props = {};
-	for (const property of globalProperties) {
-		props[property] = {
-			get() {
-				return getGlobal(property);
-			}
-		};
+const getGlobal = property => {
+	/* istanbul ignore next */
+	if (typeof self !== 'undefined' && self && property in self) {
+		return self;
 	}
 
-	Object.defineProperties(globals, props);
+	/* istanbul ignore next */
+	if (typeof window !== 'undefined' && window && property in window) {
+		return window;
+	}
+
+	if (typeof global !== 'undefined' && global && property in global) {
+		return global;
+	}
+
+	/* istanbul ignore next */
+	if (typeof globalThis !== 'undefined' && globalThis) {
+		return globalThis;
+	}
+};
+
+const globalProperties = [
+	'Headers',
+	'Request',
+	'Response',
+	'ReadableStream',
+	'fetch',
+	'AbortController',
+	'FormData'
+];
+
+for (const property of globalProperties) {
+	Object.defineProperty(globals, property, {
+		get() {
+			return getGlobal(property)[property];
+		}
+	});
 }
 
 const isObject = value => value !== null && typeof value === 'object';

--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ const globalProperties = [
 for (const property of globalProperties) {
 	Object.defineProperty(globals, property, {
 		get() {
-			return getGlobal(property)[property];
+			const globalObject = getGlobal(property);
+			const value = globalObject[property];
+			return typeof value === 'function' ? value.bind(globalObject) : value;
 		}
 	});
 }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ for (const property of globalProperties) {
 	Object.defineProperty(globals, property, {
 		get() {
 			const globalObject = getGlobal(property);
-			const value = globalObject[property];
+			const value = globalObject && globalObject[property];
 			return typeof value === 'function' ? value.bind(globalObject) : value;
 		}
 	});


### PR DESCRIPTION
Fixes #202 

This PR restores the global property lookup behavior that we had prior to PR #153, while still supporting the use case outlined in #151.

This fix is critical for anyone who mocks `window` in Node.js with any of our globals.