### PR TITLE
Move named exports to properties of default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -453,8 +453,8 @@ declare const ky: {
 	```
 	*/
 	readonly stop: unique symbol;
-	readonly TimeoutError: TimeoutError;
-	readonly HTTPError: HTTPError;
+	readonly TimeoutError: typeof TimeoutError;
+	readonly HTTPError: typeof HTTPError;
 };
 
 export default ky;

--- a/index.d.ts
+++ b/index.d.ts
@@ -331,7 +331,7 @@ export interface ResponsePromise extends Promise<Response> {
 /**
 The error has a response property with the `Response` object.
 */
-export class HTTPError extends Error {
+declare class HTTPError extends Error {
 	constructor(response: Response);
 	response: Response;
 }
@@ -339,7 +339,7 @@ export class HTTPError extends Error {
 /**
 The error thrown when the request times out.
 */
-export class TimeoutError extends Error {
+declare class TimeoutError extends Error {
 	constructor();
 }
 
@@ -453,6 +453,8 @@ declare const ky: {
 	```
 	*/
 	readonly stop: unique symbol;
+	readonly TimeoutError: TimeoutError;
+	readonly HTTPError: HTTPError;
 };
 
 export default ky;

--- a/index.js
+++ b/index.js
@@ -455,6 +455,8 @@ const createInstance = defaults => {
 		ky[method] = (input, options) => new Ky(input, validateAndMerge(defaults, options, {method}));
 	}
 
+	ky.HTTPError = HTTPError;
+	ky.TimeoutError = TimeoutError;
 	ky.create = newDefaults => createInstance(validateAndMerge(newDefaults));
 	ky.extend = newDefaults => createInstance(validateAndMerge(defaults, newDefaults));
 	ky.stop = stop;
@@ -463,8 +465,3 @@ const createInstance = defaults => {
 };
 
 export default createInstance();
-
-export {
-	HTTPError,
-	TimeoutError
-};

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {HTTPError, TimeoutError, ResponsePromise, DownloadProgress, Options, NormalizedOptions, Input} from '.';
+import ky, {ResponsePromise, DownloadProgress, Options, NormalizedOptions, Input} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -23,8 +23,8 @@ for (const method of requestMethods) {
 
 expectType<typeof ky>(ky.create({}));
 expectType<typeof ky>(ky.extend({}));
-expectType<HTTPError>(new HTTPError(new Response));
-expectType<TimeoutError>(new TimeoutError);
+expectType<ky.HTTPError>(new ky.HTTPError(new Response()));
+expectType<ky.TimeoutError>(new ky.TimeoutError());
 
 ky(url, {
 	hooks: {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -23,8 +23,8 @@ for (const method of requestMethods) {
 
 expectType<typeof ky>(ky.create({}));
 expectType<typeof ky>(ky.extend({}));
-expectType<ky.HTTPError>(new ky.HTTPError(new Response()));
-expectType<ky.TimeoutError>(new ky.TimeoutError());
+expectType<InstanceType<typeof ky.HTTPError>>(new ky.HTTPError(new Response()));
+expectType<InstanceType<typeof ky.TimeoutError>>(new ky.TimeoutError());
 
 ky(url, {
 	hooks: {

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ import ky from 'https://unpkg.com/ky/index.js';
 In environments that do not support `import`, you can load `ky` in [UMD format](https://medium.freecodecamp.org/anatomy-of-js-module-systems-and-building-libraries-fadcd8dbd0e). For example, using `require()`:
 
 ```js
-const ky = require('ky/umd').default;
+const ky = require('ky/umd');
 ```
 
 With the UMD version, it's also easy to use `ky` [without a bundler](#how-do-i-use-this-without-a-bundler-like-webpack) or module system.
@@ -518,9 +518,7 @@ Alternatively, you can use the [`umd.js`](umd.js) file with a traditional `<scri
 <script src="https://cdn.jsdelivr.net/npm/ky@latest/umd.js"></script>
 <script>
 (async () => {
-	const client = ky.default;
-
-	const parsed = await client('https://jsonplaceholder.typicode.com/todos/1').json();
+	const parsed = await ky('https://jsonplaceholder.typicode.com/todos/1').json();
 
 	console.log(parsed.title);
 	//=> 'delectus aut autem

--- a/test/browser.js
+++ b/test/browser.js
@@ -16,8 +16,6 @@ test('prefixUrl option', withPage, async (t, page) => {
 
 	await t.throwsAsync(async () => {
 		return page.evaluate(() => {
-			window.ky = window.ky.default;
-
 			return window.ky('/foo', {prefixUrl: '/'});
 		});
 	}, /`input` must not begin with a slash when using `prefixUrl`/);
@@ -52,8 +50,6 @@ test('aborting a request', withPage, async (t, page) => {
 	await page.addScriptTag({path: './umd.js'});
 
 	const error = await page.evaluate(url => {
-		window.ky = window.ky.default;
-
 		const controller = new AbortController();
 		const request = window.ky(`${url}/test`, {signal: controller.signal}).text();
 		controller.abort();
@@ -79,8 +75,6 @@ test('throws TimeoutError even though it does not support AbortController', with
 
 	// TODO: make set a timeout for this evaluation so we don't have to wait 30s
 	const error = await page.evaluate(url => {
-		window.ky = window.ky.default;
-
 		const request = window.ky(`${url}/endless`, {timeout: 500}).text();
 		return request.catch(error_ => error_.toString());
 	}, server.url);
@@ -108,8 +102,6 @@ test('onDownloadProgress works', withPage, async (t, page) => {
 	await page.addScriptTag({path: './umd.js'});
 
 	const result = await page.evaluate(async url => {
-		window.ky = window.ky.default;
-
 		// `new TextDecoder('utf-8').decode` hangs up?
 		const decodeUTF8 = array => String.fromCharCode(...array);
 
@@ -145,8 +137,6 @@ test('throws if onDownloadProgress is not a function', withPage, async (t, page)
 	await page.addScriptTag({path: './umd.js'});
 
 	const error = await page.evaluate(url => {
-		window.ky = window.ky.default;
-
 		const request = window.ky(url, {onDownloadProgress: 1}).text();
 		return request.catch(error_ => error_.toString());
 	}, server.url);
@@ -167,8 +157,6 @@ test('throws if does not support ReadableStream', withPage, async (t, page) => {
 	await page.addScriptTag({path: './umd.js'});
 
 	const error = await page.evaluate(url => {
-		window.ky = window.ky.default;
-
 		const request = window.ky(url, {onDownloadProgress: () => {}}).text();
 		return request.catch(error_ => error_.toString());
 	}, server.url);

--- a/test/main.js
+++ b/test/main.js
@@ -3,7 +3,7 @@ import test from 'ava';
 import createTestServer from 'create-test-server';
 import body from 'body';
 import delay from 'delay';
-import ky, {TimeoutError} from '..';
+import ky from '..';
 
 const pBody = util.promisify(body);
 const fixture = 'fixture';
@@ -246,7 +246,7 @@ test('timeout option', async t => {
 		response.end(fixture);
 	});
 
-	await t.throwsAsync(ky(server.url, {timeout: 500}).text(), TimeoutError);
+	await t.throwsAsync(ky(server.url, {timeout: 500}).text(), ky.TimeoutError);
 	t.is(requestCount, 1);
 
 	await server.close();
@@ -262,7 +262,7 @@ test('timeout:false option', async t => {
 		response.end(fixture);
 	});
 
-	await t.notThrowsAsync(ky(server.url, {timeout: false}).text(), TimeoutError);
+	await t.notThrowsAsync(ky(server.url, {timeout: false}).text(), ky.TimeoutError);
 	t.is(requestCount, 1);
 
 	await server.close();

--- a/umd.d.ts
+++ b/umd.d.ts
@@ -1,2 +1,1 @@
 export {default} from 'ky';
-export * from 'ky';


### PR DESCRIPTION
Closes #205 

This PR moves `HTTPError` and `TimeoutError` to properties of the default export rather than named exports.

CommonJS users can now just use `ky` instead of `ky.default`. Also eliminates a warning logged during the build.