### PR TITLE
Port header tests from Got

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,13 @@
 root = true
 
 [*]
+spaces_around_brackets = none
 indent_style = tab
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+quote_type = single
 
 [*.yml]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,11 @@
 root = true
 
 [*]
-spaces_around_brackets = none
 indent_style = tab
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-quote_type = single
 
 [*.yml]
 indent_style = space

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"create-test-server": "2.1.1",
 		"delay": "^4.1.0",
 		"esm": "^3.2.22",
+		"form-data": "^3.0.0",
 		"node-fetch": "^2.5.0",
 		"nyc": "^14.1.1",
 		"puppeteer": "^1.15.0",

--- a/test/headers.js
+++ b/test/headers.js
@@ -198,6 +198,19 @@ test('removes undefined value headers', async t => {
 	t.is(headers['user-agent'], 'undefined');
 });
 
+test.failing('non-existent headers set to undefined are omitted', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky.get(server.url, {
+		headers: {
+			blah: undefined
+		}
+	}).json();
+
+	t.false(Reflect.has(headers, 'blah'));
+});
+
 test('preserve port in host header if non-standard port', async t => {
 	const server = await createTestServer();
 	server.get('/', echoHeaders);

--- a/test/headers.js
+++ b/test/headers.js
@@ -1,0 +1,227 @@
+import createTestServer from 'create-test-server';
+import FormData from 'form-data';
+import test from 'ava';
+import ky from '..';
+
+const echoHeaders = (request, response) => {
+	request.resume();
+	response.end(JSON.stringify(request.headers));
+};
+
+test('`user-agent`', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky.get(server.url).json();
+	t.is(
+		headers['user-agent'],
+		'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)'
+	);
+});
+
+test('`accept-encoding`', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky.get(server.url).json();
+
+	t.is(headers['accept-encoding'], 'gzip,deflate');
+});
+
+test('does not override provided `accept-encoding`', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky
+		.get(server.url, {
+			headers: {
+				'accept-encoding': 'gzip'
+			}
+		})
+		.json();
+	t.is(headers['accept-encoding'], 'gzip');
+});
+
+test('does not remove user headers from `url` object argument', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky
+		.get(server.url, {
+			hostname: server.hostname,
+			port: server.port,
+			responseType: 'json',
+			protocol: 'http:',
+			headers: {
+				'X-Request-Id': 'value'
+			}
+		})
+		.json();
+
+	t.is(headers.accept, 'application/json');
+	t.is(
+		headers['user-agent'],
+		'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)'
+	);
+	t.is(headers['accept-encoding'], 'gzip,deflate');
+	t.is(headers['x-request-id'], 'value');
+});
+
+test('`accept` header with `json` option', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	let headers = await ky.get(server.url).json();
+	t.is(headers.accept, 'application/json');
+
+	headers = await ky
+		.get(server.url, {
+			headers: {
+				accept: ''
+			}
+		})
+		.json();
+
+	t.is(headers.accept, 'application/json');
+});
+
+test('`host` header', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky.get(server.url).json();
+	t.is(headers.host, `localhost:${server.port}`);
+});
+
+test('transforms names to lowercase', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky(server.url, {
+		headers: {
+			'ACCEPT-ENCODING': 'identity'
+		},
+		responseType: 'json'
+	}).json();
+	t.is(headers['accept-encoding'], 'identity');
+});
+
+test('setting `content-length` to 0', async t => {
+	const server = await createTestServer();
+	server.post('/', echoHeaders);
+
+	const headers = await ky
+		.post(server.url, {
+			headers: {
+				'content-length': '0'
+			},
+			body: 'sup'
+		})
+		.json();
+
+	t.is(headers['content-length'], '3');
+});
+
+test('sets `content-length` to `0` when requesting PUT with empty body', async t => {
+	const server = await createTestServer();
+	server.put('/', echoHeaders);
+
+	const headers = await ky.put(server.url).json();
+
+	t.is(headers['content-length'], '0');
+});
+
+test('form-data manual `content-type` header', async t => {
+	const server = await createTestServer();
+	server.post('/', echoHeaders);
+
+	const form = new FormData();
+	form.append('a', 'b');
+	const headers = await ky
+		.post(server.url, {
+			headers: {
+				'content-type': 'custom'
+			},
+			body: form
+		})
+		.json();
+
+	t.is(headers['content-type'], 'custom');
+});
+
+test('form-data automatic `content-type` header', async t => {
+	const server = await createTestServer();
+	server.post('/', echoHeaders);
+
+	const form = new FormData();
+	form.append('a', 'b');
+	const headers = await ky.post(server.url, {
+		body: form
+	}).json();
+
+	t.is(headers['content-type'], `multipart/form-data;boundary=${form.getBoundary()}`);
+});
+
+test('form-data sets `content-length` header', async t => {
+	const server = await createTestServer();
+	server.post('/', echoHeaders);
+
+	const form = new FormData();
+	form.append('a', 'b');
+	const headers = await ky.post(server.url, {body: form}).json();
+
+	t.is(headers['content-length'], '157');
+});
+
+test('buffer as `options.body` sets `content-length` header', async t => {
+	const server = await createTestServer();
+	server.post('/', echoHeaders);
+
+	const buffer = Buffer.from('unicorn');
+	const headers = await ky.post(server.url, {
+		body: buffer
+	}).json();
+
+	t.is(Number(headers['content-length']), buffer.length);
+});
+
+test('removes undefined value headers', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky.get(server.url, {
+		headers: {
+			'user-agent': undefined
+		}
+	}).json();
+
+	t.is(headers['user-agent'], 'undefined');
+});
+
+test('preserve port in host header if non-standard port', async t => {
+	const server = await createTestServer();
+	server.get('/', echoHeaders);
+
+	const body = await ky.get(server.url).json();
+	t.is(body.host, `localhost:${server.port}`);
+});
+
+test('strip port in host header if explicit standard port (:80) & protocol (HTTP)', async t => {
+	const body = await ky.get('http://httpbin.org:80/headers').json();
+	t.is(body.headers.Host, 'httpbin.org');
+});
+
+test('strip port in host header if explicit standard port (:443) & protocol (HTTPS)', async t => {
+	const body = await ky.get('https://httpbin.org:443/headers').json();
+	t.is(body.headers.Host, 'httpbin.org');
+});
+
+test('strip port in host header if implicit standard port & protocol (HTTP)', async t => {
+	const body = await ky.get('http://httpbin.org/headers').json();
+	t.is(body.headers.Host, 'httpbin.org');
+});
+
+test('strip port in host header if implicit standard port & protocol (HTTPS)', async t => {
+	const body = await ky.get('https://httpbin.org/headers').json();
+	t.is(body.headers.Host, 'httpbin.org');
+});

--- a/test/headers.js
+++ b/test/headers.js
@@ -48,10 +48,6 @@ test('does not remove user headers from `url` object argument', async t => {
 
 	const headers = await ky
 		.get(server.url, {
-			hostname: server.hostname,
-			port: server.port,
-			responseType: 'json',
-			protocol: 'http:',
 			headers: {
 				'X-Request-Id': 'value'
 			}
@@ -208,7 +204,7 @@ test.failing('non-existent headers set to undefined are omitted', async t => {
 		}
 	}).json();
 
-	t.false(Reflect.has(headers, 'blah'));
+	t.false('blah' in headers);
 });
 
 test('preserve port in host header if non-standard port', async t => {


### PR DESCRIPTION
Porting headers re: #179 

Ported all tests that seemed relevant. These are the tests I didn't: 
- [does not set `accept-encoding` header when `options.decompress` is false'](https://github.com/sindresorhus/got/blob/62cdeec4838293bf61a80820b42ecc84c408c973/test/headers.ts#L60)
   - This did set accept-encoding header. I think `options.decompress` doesn't exist on fetch, so I've omitted. 
- [stream as `options.body` sets `content-length` header](https://github.com/sindresorhus/got/blob/62cdeec4838293bf61a80820b42ecc84c408c973/test/headers.ts#L163)
   - I'm not sure this is relevant for KY. If it is, I can add the test. 
- [throws on null value headers](https://github.com/sindresorhus/got/blob/62cdeec4838293bf61a80820b42ecc84c408c973/test/headers.ts#L186)
   - This threw a 404 `HTTPError`, not a `TypeError`. Maybe I'm doing something wrong? 
- [non-existent headers set to undefined are omitted](https://github.com/sindresorhus/got/blob/62cdeec4838293bf61a80820b42ecc84c408c973/test/headers.ts#L210)
   - These weren't omitted. It looked to me this functionality isn't support yet it KY. 

Additionally, there were two other tests where ended up with different assertions but opted to keep them in:
- [accept` header with `json` option'](https://github.com/sindresorhus/got/blob/62cdeec4838293bf61a80820b42ecc84c408c973/test/headers.ts#L70)
   - When setting `accept` to `''`, `headers.accept` was still 'application/json' 
- [setting `content-length` to 0'](https://github.com/sindresorhus/got/blob/62cdeec4838293bf61a80820b42ecc84c408c973/test/headers.ts#L103)
   - Setting content length to 0 did not set the content length to 0. 