### PR TITLE
Fix handling of falsy value with the `json` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ export interface Options extends RequestInit {
 
 	Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 	*/
-	json?: object | Array | string | number | boolean | null;
+	json?: unknown;
 
 	/**
 	Search parameters to include in the request URL. Setting this will override all existing search parameters in the input URL.

--- a/index.d.ts
+++ b/index.d.ts
@@ -164,9 +164,9 @@ export interface Options extends RequestInit {
 	/**
 	Shortcut for sending JSON. Use this instead of the `body` option.
 
-	Accepts a plain object which will be `JSON.stringify()`'d and the correct header will be set for you.
+	Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 	*/
-	json?: unknown;
+	json?: any;
 
 	/**
 	Search parameters to include in the request URL. Setting this will override all existing search parameters in the input URL.

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ export interface Options extends RequestInit {
 
 	Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 	*/
-	json?: object | Array | string | number | boolean | null | undefined;
+	json?: object | Array | string | number | boolean | null;
 
 	/**
 	Search parameters to include in the request URL. Setting this will override all existing search parameters in the input URL.

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ export interface Options extends RequestInit {
 
 	Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 	*/
-	json?: any;
+	json?: object | Array | string | number | boolean | null | undefined;
 
 	/**
 	Search parameters to include in the request URL. Setting this will override all existing search parameters in the input URL.

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ class Ky {
 			this.request = new globals.Request(new globals.Request(url, this.request), this._options);
 		}
 
-		if ('json' in this._options) {
+		if (this._options.json !== undefined) {
 			this._options.body = JSON.stringify(this._options.json);
 			this.request.headers.set('content-type', 'application/json');
 			this.request = new globals.Request(this.request, {body: this._options.body});

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ class Ky {
 			this.request = new globals.Request(new globals.Request(url, this.request), this._options);
 		}
 
-		if (this._options.json) {
+		if (this._options.json !== undefined) {
 			this._options.body = JSON.stringify(this._options.json);
 			this.request.headers.set('content-type', 'application/json');
 			this.request = new globals.Request(this.request, {body: this._options.body});

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ class Ky {
 			this.request = new globals.Request(new globals.Request(url, this.request), this._options);
 		}
 
-		if (this._options.json !== undefined) {
+		if (this._options.hasOwnProperty('json')) {
 			this._options.body = JSON.stringify(this._options.json);
 			this.request.headers.set('content-type', 'application/json');
 			this.request = new globals.Request(this.request, {body: this._options.body});

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ class Ky {
 			this.request = new globals.Request(new globals.Request(url, this.request), this._options);
 		}
 
-		if (Object.prototype.hasOwnProperty.call(this._options, 'json')) {
+		if ('json' in this._options) {
 			this._options.body = JSON.stringify(this._options.json);
 			this.request.headers.set('content-type', 'application/json');
 			this.request = new globals.Request(this.request, {body: this._options.body});

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ class Ky {
 			this.request = new globals.Request(new globals.Request(url, this.request), this._options);
 		}
 
-		if (this._options.hasOwnProperty('json')) {
+		if (Object.prototype.hasOwnProperty.call(this._options, 'json')) {
 			this._options.body = JSON.stringify(this._options.json);
 			this.request.headers.set('content-type', 'application/json');
 			this.request = new globals.Request(this.request, {body: this._options.body});

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ Internally, the standard methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DEL
 
 ##### json
 
-Type: `object | Array | string | number | boolean | null | undefined`
+Type: `object | Array | string | number | boolean | null`
 
 Shortcut for sending JSON. Use this instead of the `body` option. Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 

--- a/readme.md
+++ b/readme.md
@@ -139,9 +139,9 @@ Internally, the standard methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DEL
 
 ##### json
 
-Type: `object`
+Type: `any`
 
-Shortcut for sending JSON. Use this instead of the `body` option. Accepts a plain object which will be `JSON.stringify()`'d and the correct header will be set for you.
+Shortcut for sending JSON. Use this instead of the `body` option. Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 
 ##### searchParams
 

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ Internally, the standard methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DEL
 
 ##### json
 
-Type: `any`
+Type: `object | Array | string | number | boolean | null | undefined`
 
 Shortcut for sending JSON. Use this instead of the `body` option. Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ Internally, the standard methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DEL
 
 ##### json
 
-Type: `object | Array | string | number | boolean | null`
+Type: `object` or other value supported by [JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
 
 Shortcut for sending JSON. Use this instead of the `body` option. Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ Internally, the standard methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DEL
 
 ##### json
 
-Type: `object` or other value supported by [JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
+Type: `object` and any other value accepted by [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
 
 Shortcut for sending JSON. Use this instead of the `body` option. Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
 

--- a/test/main.js
+++ b/test/main.js
@@ -547,3 +547,17 @@ test('options override Request instance body', async t => {
 
 	await server.close();
 });
+
+test('POST JSON with falsey value', async t => { // #222
+	const server = await createTestServer();
+	server.post('/', async (request, response) => {
+		response.json(JSON.parse(await pBody(request)));
+	});
+
+	const json = false;
+	const responseJson = await ky.post(server.url, {json}).json();
+
+	t.deepEqual(json, responseJson);
+
+	await server.close();
+});

--- a/test/main.js
+++ b/test/main.js
@@ -103,7 +103,7 @@ test('POST JSON', async t => {
 
 	const responseJson = await ky.post(server.url, {json}).json();
 
-	t.deepEqual(json, responseJson);
+	t.deepEqual(responseJson, json);
 
 	await server.close();
 });
@@ -144,7 +144,7 @@ test('`json` option overrides the `body` option', async t => {
 		json
 	}).json();
 
-	t.deepEqual(json, responseJson);
+	t.deepEqual(responseJson, json);
 
 	await server.close();
 });
@@ -183,7 +183,7 @@ test('JSON with custom Headers instance', async t => {
 		json
 	}).json();
 
-	t.deepEqual(json, responseJson);
+	t.deepEqual(responseJson, json);
 
 	await server.close();
 });
@@ -557,7 +557,7 @@ test('POST JSON with falsey value', async t => { // #222
 	const json = false;
 	const responseJson = await ky.post(server.url, {json}).json();
 
-	t.deepEqual(json, responseJson);
+	t.deepEqual(responseJson, json);
 
 	await server.close();
 });


### PR DESCRIPTION
Currently, falsey json values will get mistaken for an empty json value -- this makes the comparison more specific, and will match any json value other than `undefined`

Fixes #222