### PR TITLE
Fix retries for requests with a body

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,10 +389,10 @@ class Ky {
 		}
 
 		if (this._options.timeout === false) {
-			return globals.fetch(this.request);
+			return globals.fetch(this.request.clone());
 		}
 
-		return timeout(globals.fetch(this.request), this._options.timeout, this.abortController);
+		return timeout(globals.fetch(this.request.clone()), this._options.timeout, this.abortController);
 	}
 
 	/* istanbul ignore next */

--- a/test/browser.js
+++ b/test/browser.js
@@ -254,7 +254,7 @@ test('retry with body', withPage, async (t, page) => {
 	server.put('/test', async (request, response) => {
 		requestCount++;
 		await pBody(request);
-		response.sendStatus(408);
+		response.sendStatus(502);
 	});
 
 	await page.goto(server.url);
@@ -269,7 +269,7 @@ test('retry with body', withPage, async (t, page) => {
 		}).text();
 		return request.catch(error_ => error_.toString());
 	}, server.url);
-	t.is(error, 'HTTPError: Request Timeout');
+	t.is(error, 'HTTPError: Bad Gateway');
 	t.is(requestCount, 2);
 
 	await server.close();

--- a/test/browser.js
+++ b/test/browser.js
@@ -4,6 +4,8 @@ import {serial as test} from 'ava';
 import createTestServer from 'create-test-server';
 import withPage from './helpers/with-page';
 
+const pBody = util.promisify(body);
+
 test('prefixUrl option', withPage, async (t, page) => {
 	const server = await createTestServer();
 	server.get('/', (request, response) => {
@@ -73,22 +75,24 @@ test('throws TimeoutError even though it does not support AbortController', with
 		response.end();
 	});
 
-	server.get('/endless', () => {});
+	server.get('/slow', (request, response) => {
+		setTimeout(() => {
+			response.end('ok');
+		}, 1000);
+	});
 
 	await page.goto(server.url);
 	await page.addScriptTag({path: './test/helpers/disable-abort-controller.js'});
 	await page.addScriptTag({path: './umd.js'});
 
-	// TODO: make set a timeout for this evaluation so we don't have to wait 30s
 	const error = await page.evaluate(url => {
 		window.ky = window.ky.default;
 
-		const request = window.ky(`${url}/endless`, {timeout: 500}).text();
+		const request = window.ky(`${url}/slow`, {timeout: 500}).text();
 		return request.catch(error_ => error_.toString());
 	}, server.url);
 	t.is(error, 'TimeoutError: Request timed out');
 
-	// A note from @szmarczak: await server.close() hangs on my machine
 	await server.close();
 });
 
@@ -180,12 +184,13 @@ test('throws if does not support ReadableStream', withPage, async (t, page) => {
 });
 
 test('FormData with searchParams', withPage, async (t, page) => {
+	t.plan(2);
+
 	const server = await createTestServer();
 	server.get('/', (request, response) => {
 		response.end();
 	});
 	server.post('/', async (request, response) => {
-		const pBody = util.promisify(body);
 		const requestBody = await pBody(request);
 
 		t.regex(requestBody, /bubblegum pie/);
@@ -211,6 +216,8 @@ test('FormData with searchParams', withPage, async (t, page) => {
 });
 
 test('headers are preserved when input is a Request and there are searchParams in the options', withPage, async (t, page) => {
+	t.plan(2);
+
 	const server = await createTestServer();
 	server.get('/', (request, response) => {
 		response.end();
@@ -233,6 +240,37 @@ test('headers are preserved when input is a Request and there are searchParams i
 			searchParams: 'foo=1'
 		}).text();
 	}, server.url);
+
+	await server.close();
+});
+
+test('retry with body', withPage, async (t, page) => {
+	let requestCount = 0;
+
+	const server = await createTestServer();
+	server.get('/', (request, response) => {
+		response.end('zebra');
+	});
+	server.put('/test', async (request, response) => {
+		requestCount++;
+		await pBody(request);
+		response.sendStatus(408);
+	});
+
+	await page.goto(server.url);
+	await page.addScriptTag({path: './umd.js'});
+
+	const error = await page.evaluate(url => {
+		window.ky = window.ky.default;
+		const request = window.ky(url + '/test', {
+			body: 'foo',
+			method: 'PUT',
+			retry: 2
+		}).text();
+		return request.catch(error_ => error_.toString());
+	}, server.url);
+	t.is(error, 'HTTPError: Request Timeout');
+	t.is(requestCount, 2);
 
 	await server.close();
 });


### PR DESCRIPTION
Fixes #217

I now clone the request before using it so that the body is not consumed and thus `fetch()` does not freak out when we try to reuse the request during retries, since it can still read the body.

I tried to write a test for this, however it seems to be hard to test in Node, as `node-fetch` doesn't seem to throw an error under the same circumstances that actual `fetch()` does in the browser. It should be possible to test this with Puppeteer, though I haven't tried.