### PR TITLE
Fix request cancellation on timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,8 +230,9 @@ class Ky {
 				this._options.signal.addEventListener('abort', () => {
 					this.abortController.abort();
 				});
-				this._options.signal = this.abortController.signal;
 			}
+
+			this._options.signal = this.abortController.signal;
 		}
 
 		this.request = new globals.Request(this._input, this._options);


### PR DESCRIPTION
Fixes #221 

This PR fixes a regression that was caused by a simple refactoring mistake in PR #180, which caused the request to not be aborted after a TimeoutError.

Unfortunately, while I did confirm that it works, I haven't figured out how to write a test for it. I was expecting that the abort operation would cause the client to hang up the connection, and I figured that would cause an `error` event on the test server's `request` object that I could watch for. But the abort doesn't seem to cause such an error to occur. I'm not familiar enough with the details of what AbortController does at the network connection / HTTP layer to know if there's anything else to look for.