### PR TITLE
Make ky usable in snowpack (and other places where ky is imported as module)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
 		"umd.js",
 		"umd.d.ts"
 	],
+	"main": "index.js",
+	"module": "index.js",
 	"keywords": [
 		"fetch",
 		"request",


### PR DESCRIPTION
I wanted to use ky as a module with snowpack, but it seems for this to work packages need a `module` key in their package.json.