### PR TITLE
Fix the NormalizedOptions.headers TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -286,9 +286,6 @@ export interface NormalizedOptions extends RequestInit {
 	retry: Options['retry'];
 	prefixUrl: Options['prefixUrl'];
 	onDownloadProgress: Options['onDownloadProgress'];
-
-	// New type.
-	headers: Headers;
 }
 
 /**


### PR DESCRIPTION
Fixes #240 

This PR removes a vestigial part of our `NormalizedOptions` TypeScript interface that is no longer necessary and causes issues for TypeScript users who pass the `headers` option as a plain object (as opposed to a [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) instance) and then receive it inside of a hook. The definition of `headers` now comes from `RequestInit`.

For context, in older versions of Ky, we aggressively normalized the options object passed by the user before running any hooks. However, newer versions of Ky try to avoid such normalizations in favor of constructing a [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) instance and passing that around, as it does a lot of the work for us, including normalizing the headers.