### PR TITLE
Ensure HTTPError always has a defined message

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ const stop = Symbol('stop');
 
 class HTTPError extends Error {
 	constructor(response) {
-		super(response.statusText);
+		super(response.statusText || response.status || 'Unknown response error');
 		this.name = 'HTTPError';
 		this.response = response;
 	}

--- a/index.js
+++ b/index.js
@@ -118,10 +118,14 @@ const stop = Symbol('stop');
 
 class HTTPError extends Error {
 	constructor(response) {
+		// Set the message to the status text, such as Unauthorized,
+		// with some fallbacks. This message should never be undefined.
 		super(
 			response.statusText ||
-			(response.status && String(response.status)) ||
-			'Unknown response error'
+			String(
+				response.status === 0 || response.status ?
+					response.status : 'Unknown response error'
+			)
 		);
 		this.name = 'HTTPError';
 		this.response = response;

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ class HTTPError extends Error {
 		super(
 			response.statusText ||
 			String(
-				response.status === 0 || response.status ?
+				(response.status === 0 || response.status) ?
 					response.status : 'Unknown response error'
 			)
 		);

--- a/index.js
+++ b/index.js
@@ -118,7 +118,11 @@ const stop = Symbol('stop');
 
 class HTTPError extends Error {
 	constructor(response) {
-		super(response.statusText || response.status || 'Unknown response error');
+		super(
+			response.statusText ||
+			(response.status && String(response.status)) ||
+			'Unknown response error'
+		);
 		this.name = 'HTTPError';
 		this.response = response;
 	}

--- a/test/http-error.js
+++ b/test/http-error.js
@@ -35,3 +35,12 @@ test('HTTPError handles undefined response.status', t => {
 
 	t.is(error.message, 'Unknown response error');
 });
+
+test('HTTPError handles a response.status of 0', t => {
+	const error = new ky.HTTPError(
+		// Apparently, it's possible to get a response status of 0.
+		createFakeResponse({statusText: undefined, status: 0})
+	);
+
+	t.is(error.message, '0');
+});

--- a/test/http-error.js
+++ b/test/http-error.js
@@ -1,0 +1,37 @@
+import http from 'http';
+import test from 'ava';
+import ky from '..';
+
+function createFakeResponse({status, statusText}) {
+	// The request is only used to set some response defaults.
+	const request = http.request('http://example.com');
+	const response = new http.ServerResponse(request);
+	response.end();
+
+	response.status = status;
+	response.statusText = statusText;
+
+	return response;
+}
+
+test('HTTPError handles undefined response.statusText', t => {
+	const status = 500;
+	const error = new ky.HTTPError(
+		// This simulates the case where a browser Response object does
+		// not defined statusText, such as IE, Safari, etc.
+		// See https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText#Browser_compatibility
+		createFakeResponse({statusText: undefined, status})
+	);
+
+	t.is(error.message, String(status));
+});
+
+test('HTTPError handles undefined response.status', t => {
+	const error = new ky.HTTPError(
+		// This simulates a catastrophic case where some unexpected response
+		// object was sent to HTTPError.
+		createFakeResponse({statusText: undefined, status: undefined})
+	);
+
+	t.is(error.message, 'Unknown response error');
+});

--- a/test/http-error.js
+++ b/test/http-error.js
@@ -1,13 +1,13 @@
-import http from 'http';
 import test from 'ava';
+import {Response} from 'node-fetch';
 import ky from '..';
 
 function createFakeResponse({status, statusText}) {
-	// The request is only used to set some response defaults.
-	const request = http.request('http://example.com');
-	const response = new http.ServerResponse(request);
-	response.end();
+	// Start with a realistic fetch Response.
+	const response = {...new Response()};
 
+	// Assign these values because the Response() constructor doesn't
+	// support setting them to undefined.
 	response.status = status;
 	response.statusText = statusText;
 
@@ -18,7 +18,7 @@ test('HTTPError handles undefined response.statusText', t => {
 	const status = 500;
 	const error = new ky.HTTPError(
 		// This simulates the case where a browser Response object does
-		// not defined statusText, such as IE, Safari, etc.
+		// not define statusText, such as IE, Safari, etc.
 		// See https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText#Browser_compatibility
 		createFakeResponse({statusText: undefined, status})
 	);
@@ -28,8 +28,8 @@ test('HTTPError handles undefined response.statusText', t => {
 
 test('HTTPError handles undefined response.status', t => {
 	const error = new ky.HTTPError(
-		// This simulates a catastrophic case where some unexpected response
-		// object was sent to HTTPError.
+		// This simulates a catastrophic case where some unexpected
+		// response object was sent to HTTPError.
 		createFakeResponse({statusText: undefined, status: undefined})
 	);
 


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/ky/issues/248

This ensures HTTPError will always have a defined message in various situations.