### PR TITLE
Fix TypeError on Edge 18

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ class Ky {
 			// TODO: credentials can be removed when the spec change is implemented in all browsers. Context: https://www.chromestatus.com/feature/4539473312350208
 			credentials: this._input.credentials || 'same-origin',
 			...options,
-			headers: mergeHeaders(this._input.headers || {}, options.headers),
+			headers: mergeHeaders(isObject(this._input.headers) ? this._input.headers : {}, options.headers),
 			hooks: deepMerge({
 				beforeRequest: [],
 				beforeRetry: [],

--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ const supportsStreams = typeof globals.ReadableStream === 'function';
 const supportsFormData = typeof globals.FormData === 'function';
 
 const mergeHeaders = (source1, source2) => {
+	if (!isObject(source1)) {
+		throw new TypeError('The `source1` argument must be an object');
+	}
+
 	const result = new globals.Headers(source1);
 	const isHeadersInstance = source2 instanceof globals.Headers;
 	const source = new globals.Headers(source2);

--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ class Ky {
 			// TODO: credentials can be removed when the spec change is implemented in all browsers. Context: https://www.chromestatus.com/feature/4539473312350208
 			credentials: this._input.credentials || 'same-origin',
 			...options,
-			headers: mergeHeaders(this._input.headers, options.headers),
+			headers: mergeHeaders(this._input.headers || {}, options.headers),
 			hooks: deepMerge({
 				beforeRequest: [],
 				beforeRetry: [],

--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ class Ky {
 			// TODO: credentials can be removed when the spec change is implemented in all browsers. Context: https://www.chromestatus.com/feature/4539473312350208
 			credentials: this._input.credentials || 'same-origin',
 			...options,
-			headers: mergeHeaders(isObject(this._input.headers) ? this._input.headers : {}, options.headers),
+			headers: mergeHeaders(this._input.headers, options.headers),
 			hooks: deepMerge({
 				beforeRequest: [],
 				beforeRetry: [],

--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ class Ky {
 			// TODO: credentials can be removed when the spec change is implemented in all browsers. Context: https://www.chromestatus.com/feature/4539473312350208
 			credentials: this._input.credentials || 'same-origin',
 			...options,
-			headers: mergeHeaders(this._input.headers, options.headers),
+			headers: mergeHeaders(isObject(this._input.headers) ? this._input.headers : {}, options.headers),
 			hooks: deepMerge({
 				beforeRequest: [],
 				beforeRetry: [],


### PR DESCRIPTION
Fixes TypeError with edge 18 and probably a bunch of older browsers. I took a different approach from https://github.com/sindresorhus/ky/pull/261, while we are tackling the same problem. 

IMO the fix should not be made in `mergeHeaders`, but in the Ky constructor. The `this._input` is `string|Url|Request`, headers won't be present if a string is passed (url)... Modern browsers won't care so much and merge with 'undefined', but the error seems legit to me. 

Regarding testing, it's almost impossible to test this. At least I've tested on browserstack with success (edge 18 on Window 10).


## Will close

- [ ] https://github.com/sindresorhus/ky/issues/260


## Notes:

As reported on sentry

![image](https://user-images.githubusercontent.com/259798/86237962-036dab80-bb9d-11ea-83d8-8061c59dc5dd.png)
