### PR TITLE
Fix headers construction in old browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,9 @@ const supportsStreams = typeof globals.ReadableStream === 'function';
 const supportsFormData = typeof globals.FormData === 'function';
 
 const mergeHeaders = (source1, source2) => {
-	const result = new globals.Headers(source1);
+	const result = new globals.Headers(source1 || {});
 	const isHeadersInstance = source2 instanceof globals.Headers;
-	const source = new globals.Headers(source2);
+	const source = new globals.Headers(source2 || {});
 
 	for (const [key, value] of source) {
 		if ((isHeadersInstance && value === 'undefined') || value === undefined) {


### PR DESCRIPTION
Closes #260 

_This is a redo of PR #261, because the tests on that PR are exhibiting some unexpected behavior that I haven't been able to determine the root cause of, but are most likely git related, possibly even a backend issue with GitHub._