### PR TITLE
Add option for custom `fetch` implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -333,6 +333,26 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 	*/
 	onDownloadProgress?: (progress: DownloadProgress, chunk: Uint8Array) => void;
 
+	/**
+	User-defined fetch function.
+
+	Use-cases:
+	1. Use custom `fetch` implementations like [isomorphic-unfetch](https://www.npmjs.com/package/isomorphic-unfetch).
+	2. Use the `fetch` wrapper function provided by some frameworks that use server-side rendering (SSR).
+
+	 @default fetch()
+
+	```js
+	import ky from 'ky';
+	import fetch from 'isomorphic-unfetch';
+
+	(async () => {
+		const parsed = await ky('https://example.com', {
+			fetch: fetch
+		}).json();
+	})();
+	```
+	 */
 	fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -334,15 +334,16 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 	onDownloadProgress?: (progress: DownloadProgress, chunk: Uint8Array) => void;
 
 	/**
-	User-defined fetch function.
+	User-defined `fetch` function.
 
 	Use-cases:
-	1. Use custom `fetch` implementations like [isomorphic-unfetch](https://www.npmjs.com/package/isomorphic-unfetch).
+	1. Use custom `fetch` implementations like [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch).
 	2. Use the `fetch` wrapper function provided by some frameworks that use server-side rendering (SSR).
 
-	 @default fetch()
+	@default fetch
 
-	```js
+	@example
+	```
 	import ky from 'ky';
 	import fetch from 'isomorphic-unfetch';
 
@@ -352,7 +353,7 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 		}).json();
 	})();
 	```
-	 */
+	*/
 	fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -335,6 +335,7 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 
 	/**
 	User-defined `fetch` function.
+	Has to be fully compatible with the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) standard.
 
 	Use-cases:
 	1. Use custom `fetch` implementations like [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch).

--- a/index.d.ts
+++ b/index.d.ts
@@ -350,7 +350,7 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 
 	(async () => {
 		const parsed = await ky('https://example.com', {
-			fetch,
+			fetch
 		}).json();
 	})();
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -349,7 +349,7 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 
 	(async () => {
 		const parsed = await ky('https://example.com', {
-			fetch: fetch
+			fetch,
 		}).json();
 	})();
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -332,6 +332,8 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 	```
 	*/
 	onDownloadProgress?: (progress: DownloadProgress, chunk: Uint8Array) => void;
+
+	fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ for (const property of globalProperties) {
 			const globalObject = getGlobal(property);
 			const value = globalObject && globalObject[property];
 			return typeof value === 'function' ? value.bind(globalObject) : value;
-		}
+		},
+		configurable: true
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -39,8 +39,7 @@ for (const property of globalProperties) {
 			const globalObject = getGlobal(property);
 			const value = globalObject && globalObject[property];
 			return typeof value === 'function' ? value.bind(globalObject) : value;
-		},
-		configurable: true
+		}
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -289,6 +289,14 @@ class Ky {
 			this.request = new globals.Request(this.request, {body: this._options.body});
 		}
 
+		if (this._options.fetch !== undefined) {
+			Object.defineProperty(globals, 'fetch', {
+				get() {
+					return this._options.fetch;
+				}
+			});
+		}
+
 		const fn = async () => {
 			if (this._options.timeout > maxSafeTimeout) {
 				throw new RangeError(`The \`timeout\` option cannot be greater than ${maxSafeTimeout}`);

--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ class Ky {
 
 		if (this._options.fetch !== undefined) {
 			Object.defineProperty(globals, 'fetch', {
-				get() {
+				get: () => {
 					return this._options.fetch;
 				}
 			});

--- a/readme.md
+++ b/readme.md
@@ -368,6 +368,28 @@ import bourne from '@hapijs/bourne';
 })();
 ```
 
+##### fetch
+
+Type: `Function`\
+Default: `fetch()`
+
+User-defined fetch function.
+
+Use-cases:
+1. Use custom `fetch` implementations like [isomorphic-unfetch](https://www.npmjs.com/package/isomorphic-unfetch).
+2. Use the `fetch` wrapper function provided by some frameworks that use server-side rendering (SSR).
+
+```js
+import ky from 'ky';
+import fetch from 'isomorphic-unfetch';
+
+(async () => {
+	const parsed = await ky('https://example.com', {
+		fetch: fetch
+	}).json();
+})();
+```
+
 ### ky.extend(defaultOptions)
 
 Create a new `ky` instance with some defaults overridden with your own.

--- a/readme.md
+++ b/readme.md
@@ -385,7 +385,7 @@ import fetch from 'isomorphic-unfetch';
 
 (async () => {
 	const parsed = await ky('https://example.com', {
-		fetch: fetch
+		fetch
 	}).json();
 })();
 ```

--- a/readme.md
+++ b/readme.md
@@ -371,12 +371,12 @@ import bourne from '@hapijs/bourne';
 ##### fetch
 
 Type: `Function`\
-Default: `fetch()`
+Default: `fetch`
 
-User-defined fetch function.
+User-defined `fetch` function.
 
 Use-cases:
-1. Use custom `fetch` implementations like [isomorphic-unfetch](https://www.npmjs.com/package/isomorphic-unfetch).
+1. Use custom `fetch` implementations like [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch).
 2. Use the `fetch` wrapper function provided by some frameworks that use server-side rendering (SSR).
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -374,6 +374,7 @@ Type: `Function`\
 Default: `fetch`
 
 User-defined `fetch` function.
+Has to be fully compatible with the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) standard.
 
 Use-cases:
 1. Use custom `fetch` implementations like [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch).

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -23,7 +23,7 @@ test.serial('fetch option takes a custom fetch function', async t => {
 	};
 
 	t.is(await ky('/unicorn', {fetch: customFetch}).text(), '/unicorn');
-	t.is(await ky('/unicorn', {fetch: customFetch, searchParams: { foo: 'bar'} }).text(), '/unicorn?foo=bar');
+	t.is(await ky('/unicorn', {fetch: customFetch, searchParams: {foo: 'bar'}}).text(), '/unicorn?foo=bar');
 	t.is(await ky('/unicorn#hash', {fetch: customFetch, searchParams: 'foo'}).text(), '/unicorn?foo=#hash');
 	t.is(await ky('/unicorn?old', {fetch: customFetch, searchParams: 'new'}).text(), '/unicorn?new=');
 	t.is(await ky('/unicorn?old#hash', {fetch: customFetch, searchParams: 'new'}).text(), '/unicorn?new=#hash');

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -21,7 +21,7 @@ test('fetch option takes a custom fetch function', async t => {
 	t.plan(7);
 
 	const customFetch = async input => {
-		t.is(input instanceof Request);
+		t.true(input instanceof Request);
 		return new Response(input.url);
 	};
 

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -18,7 +18,7 @@ test.serial('relative URLs are passed to fetch unresolved', async t => {
 });
 
 test('fetch option takes a custom fetch function', async t => {
-	t.plan(7);
+	t.plan(12);
 
 	const customFetch = async input => {
 		t.true(input instanceof Request);

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -22,10 +22,10 @@ test.serial('fetch option takes a custom fetch function', async t => {
 		return new Response(input.url);
 	};
 
-	t.is(await ky('/unicorn', { fetch: customFetch }).text(), '/unicorn');
-	t.is(await ky('/unicorn', { fetch: customFetch, searchParams: { foo: 'bar' } }).text(), '/unicorn?foo=bar');
-	t.is(await ky('/unicorn#hash', { fetch: customFetch, searchParams: 'foo' }).text(), '/unicorn?foo=#hash');
-	t.is(await ky('/unicorn?old', { fetch: customFetch, searchParams: 'new' }).text(), '/unicorn?new=');
-	t.is(await ky('/unicorn?old#hash', { fetch: customFetch, searchParams: 'new' }).text(), '/unicorn?new=#hash');
-	t.is(await ky('unicorn', { fetch: customFetch, prefixUrl: '/api/' }).text(), '/api/unicorn');
+	t.is(await ky('/unicorn', {fetch: customFetch}).text(), '/unicorn');
+	t.is(await ky('/unicorn', {fetch: customFetch, searchParams: { foo: 'bar'} }).text(), '/unicorn?foo=bar');
+	t.is(await ky('/unicorn#hash', {fetch: customFetch, searchParams: 'foo'}).text(), '/unicorn?foo=#hash');
+	t.is(await ky('/unicorn?old', {fetch: customFetch, searchParams: 'new'}).text(), '/unicorn?new=');
+	t.is(await ky('/unicorn?old#hash', {fetch: customFetch, searchParams: 'new'}).text(), '/unicorn?new=#hash');
+	t.is(await ky('unicorn', {fetch: customFetch, prefixUrl: '/api/'}).text(), '/api/unicorn');
 });

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -17,8 +17,11 @@ test.serial('relative URLs are passed to fetch unresolved', async t => {
 	global.fetch = originalFetch;
 });
 
-test.serial('fetch option takes a custom fetch function', async t => {
+test('fetch option takes a custom fetch function', async t => {
+	t.plan(7);
+
 	const customFetch = async input => {
+		t.is(input instanceof Request);
 		return new Response(input.url);
 	};
 

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -16,3 +16,16 @@ test.serial('relative URLs are passed to fetch unresolved', async t => {
 	t.is(await ky('unicorn', {prefixUrl: '/api/'}).text(), '/api/unicorn');
 	global.fetch = originalFetch;
 });
+
+test.serial('fetch option takes a custom fetch function', async t => {
+	const customFetch = async input => {
+		return new Response(input.url);
+	};
+
+	t.is(await ky('/unicorn', { fetch: customFetch }).text(), '/unicorn');
+	t.is(await ky('/unicorn', { fetch: customFetch, searchParams: { foo: 'bar' } }).text(), '/unicorn?foo=bar');
+	t.is(await ky('/unicorn#hash', { fetch: customFetch, searchParams: 'foo' }).text(), '/unicorn?foo=#hash');
+	t.is(await ky('/unicorn?old', { fetch: customFetch, searchParams: 'new' }).text(), '/unicorn?new=');
+	t.is(await ky('/unicorn?old#hash', { fetch: customFetch, searchParams: 'new' }).text(), '/unicorn?new=#hash');
+	t.is(await ky('unicorn', { fetch: customFetch, prefixUrl: '/api/' }).text(), '/api/unicorn');
+});


### PR DESCRIPTION
As requested in #269, this PR adds the ability to pass a `fetch` option when creating a ky instance.
This allows to use custom fetch implementations like [isomorphic-unfetch](https://www.npmjs.com/package/isomorphic-unfetch) or when using SSR in some frameworks (Sapper in my case).

## TODO
- [X] Implementation
- [x] Documentation
- [x] Tests

Fixes #269