### PR TITLE
Clarify `throwHttpErrors` and redirect interaction 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -302,7 +302,7 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 	hooks?: Hooks;
 
 	/**
-	Throw a `HTTPError` for error responses (non-2xx status codes).
+	Throw an `HTTPError` when, after following redirects, the response has a non-2xx status code. To also throw for redirects instead of following them, set the [`redirect`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters) option to `'manual'`.
 
 	Setting this to `false` may be useful if you are checking for resource availability and are expecting error responses.
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ It's just a tiny file with no dependencies.
 
 - Simpler API
 - Method shortcuts (`ky.post()`)
-- Treats non-2xx status codes as errors
+- Treats non-2xx status codes as errors (after redirects)
 - Retries failed requests
 - JSON option
 - Timeout support
@@ -317,7 +317,7 @@ import ky from 'ky';
 Type: `boolean`\
 Default: `true`
 
-Throw a `HTTPError` for error responses (non-2xx status codes).
+Throw an `HTTPError` when, after following redirects, the response has a non-2xx status code. To also throw for redirects, set the [`redirect`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters) option to `'manual'`.
 
 Setting this to `false` may be useful if you are checking for resource availability and are expecting error responses.
 

--- a/readme.md
+++ b/readme.md
@@ -317,7 +317,7 @@ import ky from 'ky';
 Type: `boolean`\
 Default: `true`
 
-Throw an `HTTPError` when, after following redirects, the response has a non-2xx status code. To also throw for redirects, set the [`redirect`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters) option to `'manual'`.
+Throw an `HTTPError` when, after following redirects, the response has a non-2xx status code. To also throw for redirects instead of following them, set the [`redirect`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters) option to `'manual'`.
 
 Setting this to `false` may be useful if you are checking for resource availability and are expecting error responses.
 


### PR DESCRIPTION
Closes #253 

This PR updates the documentation to clarify that, by default, `throwHttpErrors: true` does _not_ throw for redirects because the redirects are followed beforehand. It's possible to treat a redirect as an error, too, by setting the `redirect` option to `'manual'`. (Or you could set `redirect` to `'error'`, but then the error will be thrown by `fetch` instead of Ky, and thus it won't be a `ky.HTTPError`).