### PR TITLE
Fix handling of network errors for `beforeRetry` hook

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,9 @@ export interface Hooks {
 	beforeRequest?: BeforeRequestHook[];
 
 	/**
-	This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized input and options, an error instance and the retry count as arguments. You could, for example, modify `options.headers` here.
+	This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives an object with the normalized request and options, an error instance, and the retry count. You could, for example, modify `request.headers` here.
+
+	If the request received a response, it will be available at `error.response`. Be aware that some types of errors, such as network errors, inherently mean that a response was not received.
 
 	@example
 	```
@@ -58,7 +60,7 @@ export interface Hooks {
 		await ky('https://example.com', {
 			hooks: {
 				beforeRetry: [
-					async (input, options, errors, retryCount) => {
+					async ({request, options, error, retryCount}) => {
 						const token = await ky('https://example.com/refresh-token');
 						options.headers.set('Authorization', `token ${token}`);
 					}
@@ -522,7 +524,7 @@ declare const ky: {
 		await ky('https://example.com', {
 			hooks: {
 				beforeRetry: [
-					async (request, options, errors, retryCount) => {
+					async ({request, options, error, retryCount}) => {
 						const shouldStopRetry = await ky('https://example.com/api');
 						if (shouldStopRetry) {
 							return ky.stop;

--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ class Ky {
 				const modifiedResponse = await hook(
 					this.request,
 					this._options,
-					response.clone()
+					this._decorateResponse(response.clone())
 				);
 
 				if (modifiedResponse instanceof globals.Response) {
@@ -311,11 +311,7 @@ class Ky {
 				}
 			}
 
-			if (this._options.parseJson) {
-				response.json = async () => {
-					return this._options.parseJson(await response.text());
-				};
-			}
+			this._decorateResponse(response);
 
 			if (!response.ok && this._options.throwHttpErrors) {
 				throw new HTTPError(response);
@@ -399,6 +395,16 @@ class Ky {
 		}
 
 		return 0;
+	}
+
+	_decorateResponse(response) {
+		if (this._options.parseJson) {
+			response.json = async () => {
+				return this._options.parseJson(await response.text());
+			};
+		}
+
+		return response;
 	}
 
 	async _retry(fn) {

--- a/index.js
+++ b/index.js
@@ -311,6 +311,12 @@ class Ky {
 				}
 			}
 
+			if (this._options.parseJson) {
+				response.json = async () => {
+					return this._options.parseJson(await response.text());
+				};
+			}
+
 			if (!response.ok && this._options.throwHttpErrors) {
 				throw new HTTPError(response);
 			}
@@ -327,12 +333,6 @@ class Ky {
 				}
 
 				return this._stream(response.clone(), this._options.onDownloadProgress);
-			}
-
-			if (this._options.parseJson) {
-				response.json = async () => {
-					return this._options.parseJson(await response.text());
-				};
 			}
 
 			return response;
@@ -415,7 +415,6 @@ class Ky {
 						request: this.request,
 						options: this._options,
 						error,
-						response: error.response.clone(),
 						retryCount: this._retryCount
 					});
 

--- a/readme.md
+++ b/readme.md
@@ -253,7 +253,9 @@ const api = ky.extend({
 Type: `Function[]`\
 Default: `[]`
 
-This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives the normalized request and options, the failed response, an error instance and the retry count as arguments. You could, for example, modify `request.headers` here.
+This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives an object with the normalized request and options, an error instance, and the retry count. You could, for example, modify `request.headers` here.
+
+If the request received a response, it will be available at `error.response`. Be aware that some types of errors, such as network errors, inherently mean that a response was not received.
 
 ```js
 import ky from 'ky';
@@ -262,7 +264,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			beforeRetry: [
-				async ({request, response, options, errors, retryCount}) => {
+				async ({request, options, error, retryCount}) => {
 					const token = await ky('https://example.com/refresh-token');
 					request.headers.set('Authorization', `token ${token}`);
 				}
@@ -472,7 +474,7 @@ import ky from 'ky';
 	await ky('https://example.com', {
 		hooks: {
 			beforeRetry: [
-				async ({request, response, options, errors, retryCount}) => {
+				async ({request, options, error, retryCount}) => {
 					const shouldStopRetry = await ky('https://example.com/api');
 					if (shouldStopRetry) {
 						return ky.stop;

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -396,7 +396,7 @@ test('beforeRetry hook is called with error and retryCount', async t => {
 		hooks: {
 			beforeRetry: [
 				({error, retryCount}) => {
-					t.truthy(error);
+					t.true(error instanceof ky.HTTPError);
 					t.true(retryCount >= 1);
 				}
 			]
@@ -407,7 +407,7 @@ test('beforeRetry hook is called with error and retryCount', async t => {
 });
 
 test('beforeRetry hook is called even if the error has no response', async t => {
-	t.plan(5);
+	t.plan(6);
 
 	let requestCount = 0;
 
@@ -431,6 +431,7 @@ test('beforeRetry hook is called even if the error has no response', async t => 
 			beforeRetry: [
 				({error, retryCount}) => {
 					t.is(error.message, 'simulated network failure');
+					t.is(error.response, undefined);
 					t.is(retryCount, 1);
 					t.is(requestCount, 1);
 				}

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -292,6 +292,34 @@ test('`afterResponse` hook is called with request, normalized options, and respo
 	await server.close();
 });
 
+test('afterResponse hook with parseJson and response.json()', async t => {
+	t.plan(5);
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		response.end('text');
+	});
+
+	const json = await ky.get(server.url, {
+		parseJson(text) {
+			t.is(text, 'text');
+			return {awesome: true};
+		},
+		hooks: {
+			afterResponse: [
+				async (request, options, response) => {
+					t.true(response instanceof Response);
+					t.deepEqual(await response.json(), {awesome: true});
+				}
+			]
+		}
+	}).json();
+
+	t.deepEqual(json, {awesome: true});
+
+	await server.close();
+});
+
 test('beforeRetry hook is never called for the initial request', async t => {
 	const fixture = 'fixture';
 	const server = await createTestServer();
@@ -416,7 +444,7 @@ test('beforeRetry hook is called even if the error has no response', async t => 
 	await server.close();
 });
 
-test('beforeRetry hook with parseJson and error.response', async t => {
+test('beforeRetry hook with parseJson and error.response.json()', async t => {
 	t.plan(10);
 
 	let requestCount = 0;


### PR DESCRIPTION
Fixes #251 
Fixes #275 

The PR fixes some problems with hooks caused by how we handle responses:
 - Most importantly, it ensures that `beforeRetry` hooks get called as expected in case of a network error where no response was received. Previously, if a network error occurred, Ky would attempt to clone a non-existent response, causing an exception immediately before the `beforeRetry` hook, meaning it wouldn't be called. The simplest fix, which I've implemented here, is to just remove the `response` parameter (which was merely a shortcut) and make people use `error.response` instead, which IMO is actually a bit clearer anyway, in that it is obvious the response may be `undefined`. There are some other possible ways to fix this... we could make it a getter, or use `error.response && error.response.clone()`. Of those two alternatives, I'd prefer a getter, in order to maintain a single source of truth for what the response is.
 - Additionally, it ensures that the `response` received by `afterResponse` hooks and the `error.response` from HTTP errors has the custom `parseJson` function applied to it. I've implemented a `_decorateResponse()` method to achieve this, which can be used to apply the custom parser anywhere a response is cloned.