### PR TITLE
Fix readme typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ With plain `fetch`, it would be:
 	});
 
 	if (!response.ok) {
-		throw new HTTPError('Fetch error:', response.statusText);
+		throw new HTTPError('Fetch error: ' + response.statusText);
 	}
 
 	const parsed = await response.json();

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ With plain `fetch`, it would be:
 	});
 
 	if (!response.ok) {
-		throw new HTTPError('Fetch error: ' + response.statusText);
+		throw new HTTPError(`Fetch error: ${response.statusText}`);
 	}
 
 	const parsed = await response.json();


### PR DESCRIPTION
Updates the example in the README to pass a single argument to the custom subclass of `Error` instead of passing two separate arguments where the second argument would be ignored.

An alternative to this could be to expand on the `HTTPError` implementation in the example to set a custom message and save the response, but it's just an example and it would mean we might want to do other things too to make the examples comparable.