### PR TITLE
Fix plain `ky` in Deno

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@ class Ky {
 			return response;
 		};
 
-		const isRetriableMethod = this._options.retry.methods.includes(this.request.method.toLowerCase());
+		const isRetriableMethod = this._options.retry.methods.includes((this.request.method || 'GET').toLowerCase());
 		const result = isRetriableMethod ? this._retry(fn) : fn();
 
 		for (const [type, mimeType] of Object.entries(responseTypes)) {


### PR DESCRIPTION
Use `ky` without method shortcuts causes errors in Deno `1.4.6`:

```ts
import ky from 'https://cdn.jsdelivr.net/npm/ky@0.24.0/index.js'

ky('https://httpbin.org/get').then((i: any) => i.json()).then((i: any) => console.log(i))
```

```
❯ deno run --allow-net .\deno.ts
Check file:///C:/Users/Kid/Desktop/test/deno.ts
error: Uncaught TypeError: Cannot read property 'toLowerCase' of undefined
                const isRetriableMethod = this._options.retry.methods.includes(this.request.method.toLowerCase());
                                                                                     
              ^
    at new Ky (https://cdn.jsdelivr.net/npm/ky@0.24.0/index.js:337:86)
    at ky (https://cdn.jsdelivr.net/npm/ky@0.24.0/index.js:513:33)
    at file:///C:/Users/Kid/Desktop/test/deno.ts:3:1
```

However, method shortcuts such as `ky.get()` works.

This PR assigns a default value to `this.request.method` so it works in Deno.