### PR TITLE
Fix Deno and React Native compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom"/>
-
 type Primitive = null | undefined | string | number | boolean | symbol | bigint;
 
 type LiteralUnion<LiteralType extends BaseType, BaseType extends Primitive> =


### PR DESCRIPTION
Removed the line in `index.d.ts` that caused errors when trying to use the library in Deno. This resolves #294 and fixes #224.

I have tested it on Deno 1.5.1 with Typescript 4.0.3 and it seems to work fine.

@sholladay mentioned that they want someone proficient in Typescript to analyze potential drawbacks from doing that, so I'm leaving it up to discussion since I'm far from an expert 😅