### PR TITLE
Update `AbortError` message in the tests

### DIFF
--- a/test/browser.js
+++ b/test/browser.js
@@ -63,7 +63,7 @@ test('aborting a request', withPage, async (t, page) => {
 		controller.abort();
 		return request.catch(error_ => error_.toString());
 	}, server.url);
-	t.is(error, 'AbortError: The user aborted a request.');
+	t.is(error, 'AbortError: Failed to execute \'fetch\' on \'Window\': The user aborted a request.');
 
 	await server.close();
 });


### PR DESCRIPTION
Fixes test which started failing with [Fix handling of network errors for `beforeRetry` hook (#276)](https://github.com/sindresorhus/ky/commit/9876da129c216b99ad9f5760d38ba0ed1876d20e).

As far as I could tell, `node-fetch` is not to blame for this. I looked into its source code and could not find a matching discriminating line which would yield this error message (i.e. with the seemingly added prefix). I checked both current version and the one which is used here.

Since the tests are run with `puppeteer` I think it's Chromium's native `fetch` which is used. The `global.fetch` in [_require.js](https://github.com/sindresorhus/ky/blob/master/test/_require.js) is _not_ used for these tests (I simply tried to replace it with a function which would `throw` immediately, without any effect). 