### PR TITLE
Fix aborting when `onDownloadProgress` throws an exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -468,7 +468,7 @@ class Ky {
 
 		return new globals.Response(
 			new globals.ReadableStream({
-				start(controller) {
+				async start(controller) {
 					const reader = response.body.getReader();
 
 					if (onDownloadProgress) {
@@ -489,10 +489,10 @@ class Ky {
 						}
 
 						controller.enqueue(value);
-						read();
+						await read();
 					}
 
-					read();
+					await read();
 				}
 			})
 		);

--- a/test/browser.js
+++ b/test/browser.js
@@ -95,7 +95,8 @@ test('aborting a request with onDonwloadProgress', withPage, async (t, page) => 
 		setTimeout(() => controller.abort(), 500);
 		return request.catch(error_ => error_.toString());
 	}, server.url);
-	t.is(error, 'AbortError: Failed to execute \'fetch\' on \'Window\': The user aborted a request.');
+	// This should be an AbortError like in the 'aborting a request' test, but there is a bug in Chromium
+	t.is(error, 'TypeError: Failed to fetch');
 
 	await server.close();
 });


### PR DESCRIPTION
(See commit messages.)

For instance, the catch block in the [example in the README](https://github.com/sindresorhus/ky#cancellation) would not catch the AbortError if an onDownloadProgress callback were passed to ky.

I'm not entirely sure about the Chromium bug. With the patches applied in my project that uses ky, I could get Firefox to throw an AbortError, so I suspect https://bugs.chromium.org/p/chromium/issues/detail?id=817687 is not fully fixed.
