### PR TITLE
Fix support for `ky.stop` as return type in `BeforeRetryHook` TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export type BeforeRetryHook = (options: {
 	options: NormalizedOptions;
 	error: Error;
 	retryCount: number;
-}) => void | Promise<void>;
+}) => symbol | void | Promise<symbol | void>;
 
 export type AfterResponseHook = (
 	request: Request,

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export type BeforeRetryHook = (options: {
 	options: NormalizedOptions;
 	error: Error;
 	retryCount: number;
-}) => symbol | void | Promise<symbol | void>;
+}) => typeof ky.stop | void | Promise<typeof ky.stop | void>;
 
 export type AfterResponseHook = (
 	request: Request,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -55,6 +55,12 @@ ky(url, {
 				expectType<Error>(error);
 				expectType<number>(retryCount);
 				request.headers.set('foo', 'bar');
+			},
+			({_request, _response, _options, _error, _retryCount}) => {
+				return ky.stop;
+			},
+			async ({_request, _response, _options, _error, _retryCount}) => {
+				return ky.stop;
 			}
 		],
 		afterResponse: [

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -56,10 +56,10 @@ ky(url, {
 				expectType<number>(retryCount);
 				request.headers.set('foo', 'bar');
 			},
-			({_request, _response, _options, _error, _retryCount}) => {
+			(_options) => {
 				return ky.stop;
 			},
-			async ({_request, _response, _options, _error, _retryCount}) => {
+			async (_options) => {
 				return ky.stop;
 			}
 		],


### PR DESCRIPTION
fixes #288