### PR TITLE
Fix `BeforeRetryHook` and `NormalizedOptions` TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export type BeforeRetryOptions = {
 };
 export type BeforeRetryHook = (
 	options: BeforeRetryOptions
-) => void | Promise<void>;
+) => typeof ky.stop | void | Promise<typeof ky.stop | void>;
 
 export type AfterResponseHook = (
 	request: Request,

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export type BeforeRequestHook = (
 	options: NormalizedOptions,
 ) => Request | Response | void | Promise<Request | Response | void>;
 
-export type BeforeRetryOptions = {
+export type BeforeRetryState = {
 	request: Request;
 	response: Response;
 	options: NormalizedOptions;
@@ -19,7 +19,7 @@ export type BeforeRetryOptions = {
 	retryCount: number;
 };
 export type BeforeRetryHook = (
-	options: BeforeRetryOptions
+	options: BeforeRetryState
 ) => typeof ky.stop | void | Promise<typeof ky.stop | void>;
 
 export type AfterResponseHook = (

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export type BeforeRequestHook = (
 
 export type BeforeRetryOptions = {
 	request: Request;
-	response:  Response;
+	response: Response;
 	options: NormalizedOptions;
 	error: Error;
 	retryCount: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,13 +11,16 @@ export type BeforeRequestHook = (
 	options: NormalizedOptions,
 ) => Request | Response | void | Promise<Request | Response | void>;
 
-export type BeforeRetryHook = (options: {
+export type BeforeRetryOptions = {
 	request: Request;
-	response: Response;
+	response:  Response;
 	options: NormalizedOptions;
 	error: Error;
 	retryCount: number;
-}) => typeof ky.stop | void | Promise<typeof ky.stop | void>;
+};
+export type BeforeRetryHook = (
+	options: BeforeRetryOptions
+) => void | Promise<void>;
 
 export type AfterResponseHook = (
 	request: Request,
@@ -367,8 +370,8 @@ export interface NormalizedOptions extends RequestInit {
 	credentials: RequestInit['credentials'];
 
 	// Extended from custom `KyOptions`, but ensured to be set (not optional).
-	retry: Options['retry'];
-	prefixUrl: Options['prefixUrl'];
+	retry: RetryOptions;
+	prefixUrl: string;
 	onDownloadProgress: Options['onDownloadProgress'];
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -49,8 +49,8 @@ ky(url, {
 		],
 		beforeRetry: [
 			(beforeRetryOptions) => {
-				const {request, response, options, error, retryCount} = beforeRetryOptions
-				expectType<BeforeRetryState>(beforeRetryOptions)
+				const {request, response, options, error, retryCount} = beforeRetryOptions;
+				expectType<BeforeRetryState>(beforeRetryOptions);
 				expectType<Request>(request);
 				expectType<Response>(response);
 				expectType<NormalizedOptions>(options);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {BeforeRetryOptions, ResponsePromise, DownloadProgress, Options, NormalizedOptions, Input} from '.';
+import ky, {BeforeRetryState, ResponsePromise, DownloadProgress, Options, NormalizedOptions, Input} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -49,8 +49,8 @@ ky(url, {
 		],
 		beforeRetry: [
 			(beforeRetryOptions) => {
-				const { request, response, options, error, retryCount } = beforeRetryOptions
-				expectType<BeforeRetryOptions>(beforeRetryOptions)
+				const {request, response, options, error, retryCount} = beforeRetryOptions
+				expectType<BeforeRetryState>(beforeRetryOptions)
 				expectType<Request>(request);
 				expectType<Response>(response);
 				expectType<NormalizedOptions>(options);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import ky, {ResponsePromise, DownloadProgress, Options, NormalizedOptions, Input} from '.';
+import ky, {BeforeRetryOptions, ResponsePromise, DownloadProgress, Options, NormalizedOptions, Input} from '.';
 
 const url = 'https://sindresorhus';
 
@@ -48,7 +48,9 @@ ky(url, {
 			}
 		],
 		beforeRetry: [
-			({request, response, options, error, retryCount}) => {
+			(beforeRetryOptions) => {
+				const { request, response, options, error, retryCount } = beforeRetryOptions
+				expectType<BeforeRetryOptions>(beforeRetryOptions)
 				expectType<Request>(request);
 				expectType<Response>(response);
 				expectType<NormalizedOptions>(options);


### PR DESCRIPTION
Fixes #289 and fixes #288. The latter can be fixed by #307, but it doesn't include moving arguments that `BeforeRetryHook` receives to a separate object that can later be used to declare `beforeRetry` hooks outside of `ky.create` declaration or actual request.