### PR TITLE
Throw error when `ky.stop` is returned

### DIFF
--- a/index.js
+++ b/index.js
@@ -426,7 +426,7 @@ class Ky {
 
 					// If `stop` is returned from the hook, the retry process is stopped
 					if (hookResult === stop) {
-						return;
+						throw error;
 					}
 				}
 

--- a/readme.md
+++ b/readme.md
@@ -465,7 +465,7 @@ The error thrown when the request times out.
 
 ### ky.stop
 
-A `Symbol` that can be returned by a `beforeRetry` hook to stop the retry. This will also short circuit the remaining `beforeRetry` hooks.
+A `Symbol` that can be returned by a `beforeRetry` hook to stop the retry. This will also short circuit the remaining `beforeRetry` hooks. The original error that caused the retry attempt will be thrown.
 
 ```js
 import ky from 'ky';

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -500,7 +500,6 @@ test('beforeRetry hook can cancel retries by returning `stop` and throws the ori
 		}
 	});
 
-
 	await t.throwsAsync(ky.get(server.url, {
 		hooks: {
 			beforeRetry: [

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -486,7 +486,7 @@ test('beforeRetry hook with parseJson and error.response.json()', async t => {
 	await server.close();
 });
 
-test('beforeRetry hook can cancel retries by returning `stop`', async t => {
+test('beforeRetry hook can cancel retries by returning `stop` and throws the original error', async t => {
 	let requestCount = 0;
 
 	const server = await createTestServer();
@@ -500,7 +500,8 @@ test('beforeRetry hook can cancel retries by returning `stop`', async t => {
 		}
 	});
 
-	await ky.get(server.url, {
+
+	await t.throwsAsync(ky.get(server.url, {
 		hooks: {
 			beforeRetry: [
 				({error, retryCount}) => {
@@ -511,7 +512,7 @@ test('beforeRetry hook can cancel retries by returning `stop`', async t => {
 				}
 			]
 		}
-	});
+	}).text());
 
 	t.is(requestCount, 1);
 


### PR DESCRIPTION
Fixes #290. This also may be a breaking change although no one seems to have opened an issue that returning `ky.stop` causes `TypeError` until now.