### PR TITLE
Update recommended CDN for Deno users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ console.log(json);
 If you are using [Deno](https://github.com/denoland/deno), import Ky from a URL. For example, using a CDN:
 
 ```js
-import ky from 'https://unpkg.com/ky/index.js';
+import ky from 'https://cdn.skypack.dev/ky?dts';
 ```
 
 ## API


### PR DESCRIPTION
Closes #302

At the moment, Skypack generally has better TypeScript support than other CDNs, and thus is probably the best choice for most Deno users.

I would still recommend unpkg for everyone else, as in my experience unpkg is faster and less buggy.