### PR TITLE
Switch from Puppeteer to Playwright for reliable and concurrent browser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"form-data": "^3.0.0",
 		"node-fetch": "^2.5.0",
 		"nyc": "^15.0.0",
-		"puppeteer": "^5.5.0",
+		"playwright-chromium": "^1.7.1",
 		"tsd": "^0.13.1",
 		"xo": "^0.25.3"
 	},

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,14 +1,10 @@
 import util from 'util';
 import fs from 'fs';
 import body from 'body';
-import ava from 'ava'; // eslint-disable-line ava/use-test
+import test from 'ava';
 import createTestServer from 'create-test-server';
 import Busboy from 'busboy';
 import withPage from './helpers/with-page.js';
-
-// FIXME: Skipping tests on CI as they're unreliable there for some reason.
-// It's serial as Puppeteer cannot handle full concurrency.
-const test = process.env.CI ? ava.skip : ava.serial;
 
 const pBody = util.promisify(body);
 

--- a/test/helpers/with-page.js
+++ b/test/helpers/with-page.js
@@ -1,7 +1,7 @@
-import puppeteer from 'puppeteer';
+import {chromium} from 'playwright-chromium';
 
 export default async function withPage(t, run) {
-	const browser = await puppeteer.launch();
+	const browser = await chromium.launch();
 	const page = await browser.newPage();
 	try {
 		await run(t, page);


### PR DESCRIPTION
Making browser tests great again!

This PR makes big improvements to the reliability, install size, install time, and performance of the browser tests by switching from [Puppeteer](https://developers.google.com/web/tools/puppeteer/) to [Playwright](https://playwright.dev/). it also re-enables these tests in CI, as this fixes the test flakiness we've experienced for a long time. Further performance gains could likely be had by sharing a browser instance across tests and using Playwright's [contexts](https://playwright.dev/docs/core-concepts#browser-contexts) feature for isolation (as shown [here](https://playwright.dev/docs/test-runners#ava)), but the tests are so fast now I didn't even bother. Re-installs are speedier as well, because Chromium is cached by Playwright.

Microsoft is schooling Google at interfacing with Google's own browser. 🤣 

### Install size

 - Chromium down from **132.4 Mb** to **96.9 Mb**, a **26.8%** improvement.
 - Dependencies down from **314 MB** to **22 MB**, a **92%** improvement.

Before:
```
❯ time npm i --save-dev puppeteer

Downloading Chromium r818858 - 132.4 Mb

❯ du -sh node_modules
314M    node_modules
```

After:
```
❯ time npm i --save-dev playwright-chromium

Downloading chromium v833159 - 96.9 Mb

❯ du -sh node_modules
 22M    node_modules
```

### Install time

Down from about **18 seconds** to **13 seconds**, a **27.7%** improvement.

Before:
```
❯ time npm i --save-dev puppeteer

> puppeteer@5.5.0 install /private/tmp/foo/node_modules/puppeteer
> node install.js

Downloading Chromium r818858 - 132.4 Mb [====================] 100% 0.0s 

________________________________________________________
Executed in   18.37 secs   fish           external 
   usr time    7.84 secs  116.00 micros    7.84 secs 
   sys time    3.23 secs  611.00 micros    3.23 secs 
```

After:
```
❯ time npm i --save-dev playwright-chromium

> playwright-chromium@1.7.1 install /private/tmp/foo/node_modules/playwright-chromium
> node install.js

Downloading chromium v833159 - 96.9 Mb [====================] 100% 0.0s 

________________________________________________________
Executed in   13.68 secs   fish           external 
   usr time    6.44 secs  110.00 micros    6.44 secs 
   sys time    2.48 secs  660.00 micros    2.48 secs 
```

### Run time

Down from about **1 minute** to **11 seconds**, an **81.6%** improvement.

Before:

```
❯ time npx ava test/browser.js

  11 tests passed

________________________________________________________
Executed in   60.29 secs   fish           external 
   usr time    6.84 secs  112.00 micros    6.84 secs 
   sys time    1.97 secs  554.00 micros    1.97 secs 
```

After:

```
❯ time npx ava test/browser.js

  11 tests passed

________________________________________________________
Executed in   11.13 secs   fish           external 
   usr time   10.78 secs  123.00 micros   10.78 secs 
   sys time    3.98 secs  641.00 micros    3.98 secs 
```