### PR TITLE
Simplify global variable usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
 /*! MIT License © Sindre Sorhus */
 
-const globals = globalThis;
-
 const isObject = value => value !== null && typeof value === 'object';
-const supportsAbortController = typeof globals.AbortController === 'function';
-const supportsStreams = typeof globals.ReadableStream === 'function';
-const supportsFormData = typeof globals.FormData === 'function';
+const supportsAbortController = typeof globalThis.AbortController === 'function';
+const supportsStreams = typeof globalThis.ReadableStream === 'function';
+const supportsFormData = typeof globalThis.FormData === 'function';
 
 const mergeHeaders = (source1, source2) => {
-	const result = new globals.Headers(source1 || {});
-	const isHeadersInstance = source2 instanceof globals.Headers;
-	const source = new globals.Headers(source2 || {});
+	const result = new globalThis.Headers(source1 || {});
+	const isHeadersInstance = source2 instanceof globalThis.Headers;
+	const source = new globalThis.Headers(source2 || {});
 
 	for (const [key, value] of source) {
 		if ((isHeadersInstance && value === 'undefined') || value === undefined) {
@@ -201,10 +199,10 @@ class Ky {
 			retry: normalizeRetryOptions(options.retry),
 			throwHttpErrors: options.throwHttpErrors !== false,
 			timeout: typeof options.timeout === 'undefined' ? 10000 : options.timeout,
-			fetch: options.fetch || globals.fetch.bind(globals)
+			fetch: options.fetch || globalThis.fetch.bind(globalThis)
 		};
 
-		if (typeof this._input !== 'string' && !(this._input instanceof URL || this._input instanceof globals.Request)) {
+		if (typeof this._input !== 'string' && !(this._input instanceof URL || this._input instanceof globalThis.Request)) {
 			throw new TypeError('`input` must be a string, URL, or Request');
 		}
 
@@ -221,7 +219,7 @@ class Ky {
 		}
 
 		if (supportsAbortController) {
-			this.abortController = new globals.AbortController();
+			this.abortController = new globalThis.AbortController();
 			if (this._options.signal) {
 				this._options.signal.addEventListener('abort', () => {
 					this.abortController.abort();
@@ -231,24 +229,24 @@ class Ky {
 			this._options.signal = this.abortController.signal;
 		}
 
-		this.request = new globals.Request(this._input, this._options);
+		this.request = new globalThis.Request(this._input, this._options);
 
 		if (this._options.searchParams) {
 			const searchParams = '?' + new URLSearchParams(this._options.searchParams).toString();
 			const url = this.request.url.replace(/(?:\?.*?)?(?=#|$)/, searchParams);
 
 			// To provide correct form boundary, Content-Type header should be deleted each time when new Request instantiated from another one
-			if (((supportsFormData && this._options.body instanceof globals.FormData) || this._options.body instanceof URLSearchParams) && !(this._options.headers && this._options.headers['content-type'])) {
+			if (((supportsFormData && this._options.body instanceof globalThis.FormData) || this._options.body instanceof URLSearchParams) && !(this._options.headers && this._options.headers['content-type'])) {
 				this.request.headers.delete('content-type');
 			}
 
-			this.request = new globals.Request(new globals.Request(url, this.request), this._options);
+			this.request = new globalThis.Request(new globalThis.Request(url, this.request), this._options);
 		}
 
 		if (this._options.json !== undefined) {
 			this._options.body = JSON.stringify(this._options.json);
 			this.request.headers.set('content-type', 'application/json');
-			this.request = new globals.Request(this.request, {body: this._options.body});
+			this.request = new globalThis.Request(this.request, {body: this._options.body});
 		}
 
 		const fn = async () => {
@@ -267,7 +265,7 @@ class Ky {
 					this._decorateResponse(response.clone())
 				);
 
-				if (modifiedResponse instanceof globals.Response) {
+				if (modifiedResponse instanceof globalThis.Response) {
 					response = modifiedResponse;
 				}
 			}
@@ -427,8 +425,8 @@ class Ky {
 		const totalBytes = Number(response.headers.get('content-length')) || 0;
 		let transferredBytes = 0;
 
-		return new globals.Response(
-			new globals.ReadableStream({
+		return new globalThis.Response(
+			new globalThis.ReadableStream({
 				async start(controller) {
 					const reader = response.body.getReader();
 

--- a/index.js
+++ b/index.js
@@ -1,25 +1,6 @@
 /*! MIT License © Sindre Sorhus */
 
-const globals = {};
-
-const globalProperties = [
-	'Headers',
-	'Request',
-	'Response',
-	'ReadableStream',
-	'fetch',
-	'AbortController',
-	'FormData'
-];
-
-for (const property of globalProperties) {
-	Object.defineProperty(globals, property, {
-		get() {
-			const value = globalThis[property];
-			return typeof value === 'function' ? value.bind(globalThis) : value;
-		}
-	});
-}
+const globals = globalThis;
 
 const isObject = value => value !== null && typeof value === 'object';
 const supportsAbortController = typeof globals.AbortController === 'function';
@@ -220,7 +201,7 @@ class Ky {
 			retry: normalizeRetryOptions(options.retry),
 			throwHttpErrors: options.throwHttpErrors !== false,
 			timeout: typeof options.timeout === 'undefined' ? 10000 : options.timeout,
-			fetch: options.fetch || globals.fetch
+			fetch: options.fetch || globals.fetch.bind(globals)
 		};
 
 		if (typeof this._input !== 'string' && !(this._input instanceof URL || this._input instanceof globals.Request)) {

--- a/test/_require.js
+++ b/test/_require.js
@@ -2,9 +2,9 @@ import fetch, {Headers, Request, Response} from 'node-fetch';
 import AbortController from 'abort-controller';
 import FormData from 'form-data';
 
-global.fetch = fetch;
-global.Headers = Headers;
-global.Request = Request;
-global.Response = Response;
-global.AbortController = AbortController;
-global.FormData = FormData;
+globalThis.fetch = fetch;
+globalThis.Headers = Headers;
+globalThis.Request = Request;
+globalThis.Response = Response;
+globalThis.AbortController = AbortController;
+globalThis.FormData = FormData;

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -2,8 +2,8 @@ import test from 'ava';
 import ky from '../index.js';
 
 test.serial('relative URLs are passed to fetch unresolved', async t => {
-	const originalFetch = global.fetch;
-	global.fetch = async input => {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = async input => {
 		t.true(input.url.startsWith('/'));
 		return new Response(input.url);
 	};
@@ -14,7 +14,7 @@ test.serial('relative URLs are passed to fetch unresolved', async t => {
 	t.is(await ky('/unicorn?old', {searchParams: 'new'}).text(), '/unicorn?new=');
 	t.is(await ky('/unicorn?old#hash', {searchParams: 'new'}).text(), '/unicorn?new=#hash');
 	t.is(await ky('unicorn', {prefixUrl: '/api/'}).text(), '/api/unicorn');
-	global.fetch = originalFetch;
+	globalThis.fetch = originalFetch;
 });
 
 test('fetch option takes a custom fetch function', async t => {

--- a/test/headers.js
+++ b/test/headers.js
@@ -18,7 +18,7 @@ test.serial('works with nullish headers even in old browsers', async t => {
 	// Some old browsers throw for new Headers(undefined) or new Headers(null)
 	// so we check that Ky never does that and passes an empty object instead.
 	// See: https://github.com/sindresorhus/ky/issues/260
-	global.Headers = class Headers extends OriginalHeaders {
+	globalThis.Headers = class Headers extends OriginalHeaders {
 		constructor(headersInit) {
 			t.deepEqual(headersInit, {});
 			super(headersInit);
@@ -32,7 +32,7 @@ test.serial('works with nullish headers even in old browsers', async t => {
 
 	await server.close();
 
-	global.Headers = OriginalHeaders;
+	globalThis.Headers = OriginalHeaders;
 });
 
 test('`user-agent`', async t => {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -425,7 +425,7 @@ test('beforeRetry hook is called even if the error has no response', async t => 
 				throw new Error('simulated network failure');
 			}
 
-			return global.fetch(request);
+			return globalThis.fetch(request);
 		},
 		hooks: {
 			beforeRetry: [


### PR DESCRIPTION
As of https://github.com/sindresorhus/ky/pull/315, Ky requires the fetch related APIs to be true globals on `globalThis`, as opposed to dynamically looking them up on various namespaces. Thus the list of globals and getters for them no longer serves a purpose.