### PR TITLE
Improve HTTPError messages

### DIFF
--- a/source/errors/HTTPError.ts
+++ b/source/errors/HTTPError.ts
@@ -6,12 +6,12 @@ export class HTTPError extends Error {
 	public options: NormalizedOptions;
 
 	constructor(response: Response, request: Request, options: NormalizedOptions) {
-		// Set the message to the status text, such as Unauthorized,
-		// with some fallbacks. This message should never be undefined.
-		super(
-			response.statusText ||
-				String(response.status === 0 || response.status ? response.status : 'Unknown response error')
-		);
+		const code = (response.status || response.status === 0) ? response.status : '';
+		const title = response.statusText || '';
+		const status = `${code} ${title}`.trim();
+		const reason = status ? `status code ${status}` : 'an unknown error';
+
+		super(`Request failed with ${reason}`);
 
 		this.name = 'HTTPError';
 		this.response = response;

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -405,7 +405,7 @@ test('retry with body', withPage, async (t: ExecutionContext, page: Page) => {
 				retry: 2
 			});
 		}, server.url),
-		{message: /HTTPError: Bad Gateway/}
+		{message: /HTTPError: Request failed with status code 502 Bad Gateway/}
 	);
 
 	t.is(requestCount, 2);

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -483,7 +483,7 @@ test('beforeRetry hook with parseJson and error.response.json()', async t => {
 				beforeRetry: [
 					async ({error, retryCount}) => {
 						t.true(error instanceof ky.HTTPError);
-						t.is(error.message, 'Bad Gateway');
+						t.is(error.message, 'Request failed with status code 502 Bad Gateway');
 						t.true((error as HTTPError).response instanceof Response);
 						t.deepEqual(await (error as HTTPError).response.json(), {awesome: true});
 						t.is(retryCount, 1);

--- a/test/http-error.ts
+++ b/test/http-error.ts
@@ -25,7 +25,7 @@ test('HTTPError handles undefined response.statusText', t => {
 		createFakeResponse({statusText: undefined, status})
 	);
 
-	t.is(error.message, String(status));
+	t.is(error.message, 'Request failed with status code 502');
 });
 
 test('HTTPError handles undefined response.status', t => {
@@ -36,7 +36,7 @@ test('HTTPError handles undefined response.status', t => {
 		createFakeResponse({statusText: undefined, status: undefined})
 	);
 
-	t.is(error.message, 'Unknown response error');
+	t.is(error.message, 'Request failed with an unknown error');
 });
 
 test('HTTPError handles a response.status of 0', t => {
@@ -46,5 +46,5 @@ test('HTTPError handles a response.status of 0', t => {
 		createFakeResponse({statusText: undefined, status: 0})
 	);
 
-	t.is(error.message, '0');
+	t.is(error.message, 'Request failed with status code 0');
 });

--- a/test/http-error.ts
+++ b/test/http-error.ts
@@ -25,7 +25,7 @@ test('HTTPError handles undefined response.statusText', t => {
 		createFakeResponse({statusText: undefined, status})
 	);
 
-	t.is(error.message, 'Request failed with status code 502');
+	t.is(error.message, 'Request failed with status code 500');
 });
 
 test('HTTPError handles undefined response.status', t => {


### PR DESCRIPTION
This PR aims to provide a clearer error message to the user when an `HTTPError` occurs, by adding a description and showing both the status code and status text, when available.

Perhaps the best example of how this helps is where the response has an unusual status code, such as 0, but there is no status text, as is the case when HTTP/2 is being used.

Before:
```
HTTPError: 0
```

After:
```
HTTPError: Request failed with status 0
```

Happy to bikeshed the phrasing. Could change "failed with status" to "failed with response status", for example. Also on the fence about "an unknown error" vs "an unknown status" vs "an unknown response error", etc.