### PR TITLE
Fix throwHttpErrors: false suppressing non-HTTP errors

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -248,9 +248,7 @@ export class Ky {
 				return this._retry(fn);
 			}
 
-			if (this._options.throwHttpErrors) {
-				throw error;
-			}
+			throw error;
 		}
 	}
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -393,6 +393,26 @@ test('throwHttpErrors option with POST', async t => {
 	await server.close();
 });
 
+test('throwHttpErrors:false does not suppress timeout errors', async t => {
+	let requestCount = 0;
+
+	const server = await createHttpTestServer();
+	server.get('/', async (_request, response) => {
+		requestCount++;
+		await delay(1000);
+		response.sendStatus(500);
+	});
+
+	await t.throwsAsync(
+		ky(server.url, {throwHttpErrors: false, timeout: 500}).text(),
+		{instanceOf: ky.TimeoutError}
+	);
+
+	t.is(requestCount, 1);
+
+	await server.close();
+});
+
 test('ky.create()', async t => {
 	const server = await createHttpTestServer();
 	server.get('/', (request, response) => {


### PR DESCRIPTION
Closes #246 

This PR aims to fix some unintended behavior for people who use the `throwHttpErrors: false` option. Previously, if the method was retriable, _all_ operational errors would be suppressed, including network errors and timeout errors, not just HTTP status code errors. Now, the option _only_ suppresses errors of the `ky.HTTPError` class, which are thrown when a response is received with a non-2xx status code.