### PR TITLE
Fix merging of searchParams in create()/extend()

### DIFF
--- a/source/utils/merge.ts
+++ b/source/utils/merge.ts
@@ -52,7 +52,6 @@ export const deepMerge = <T>(...sources: Array<Partial<T> | undefined>): T => {
 				returnValue.headers = headers;
 			}
 		}
-
 	}
 
 	return returnValue;

--- a/source/utils/merge.ts
+++ b/source/utils/merge.ts
@@ -49,10 +49,10 @@ export const deepMerge = <T>(...sources: Array<Partial<T> | undefined>): T => {
 
 			if (isObject((source as any).headers)) {
 				headers = mergeHeaders(headers, (source as any).headers);
+				returnValue.headers = headers;
 			}
 		}
 
-		returnValue.headers = headers;
 	}
 
 	return returnValue;

--- a/test/main.ts
+++ b/test/main.ts
@@ -474,6 +474,18 @@ test('ky.create() with deep array', async t => {
 	await server.close();
 });
 
+test('ky.create() does not mangle search params', async t => {
+	const server = await createHttpTestServer();
+	server.get('/', (request, response) => {
+		response.end(request.url);
+	});
+
+	const instance = ky.create({searchParams: {}});
+	t.is(await instance.get(server.url, {searchParams: {}}).text(), '/?');
+
+	await server.close();
+});
+
 test('ky.extend()', async t => {
 	const server = await createHttpTestServer();
 	server.get('/', (_request, response) => {


### PR DESCRIPTION
Closes #324

This PR fixes how the `searchParams` option is handled in `ky.create()` and `ky.extend()` so that the user's expected search params are used. Previously, we were inadvertently adding a `headers` search param in some cases.