### PR TITLE
Restore `main` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"main": "./distribution/index.js",
 	"exports": "./distribution/index.js",
 	"types": "./distribution/index.d.ts",
 	"engines": {


### PR DESCRIPTION
`ky@0.28.0` can't be used in react-native apps anymore due to a missing main field in `package.json`.

Metro does provide configuration options to support extra "main" fields but adding `"exports"` there breaks as other packages start to use this field instead of their `"main"` (not sure why, as it is expected to be an ordered check, maybe a metro-related bug of the `"exports"` key handling when in object form). Haven't found a way to make it work except manually patching the ky's package.json.

```
error: Error: While trying to resolve module `ky` from file `~/foo/src/services/pumalocal/client.ts`, the package `~/foo/node_modules/ky/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`~/foo/node_modules/ky/index`. Indeed, none of these files exist:
```