### PR TITLE
Fix `searchParams` option TypeScript type

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -1,7 +1,7 @@
 import {HTTPError} from '../errors/HTTPError.js';
 import {TimeoutError} from '../errors/TimeoutError.js';
 import type {Hooks} from '../types/hooks.js';
-import type {Input, InternalOptions, NormalizedOptions, Options} from '../types/options.js';
+import type {Input, InternalOptions, NormalizedOptions, Options, SearchParamsInit} from '../types/options.js';
 import {ResponsePromise} from '../types/response.js';
 import {deepMerge, mergeHeaders} from '../utils/merge.js';
 import {normalizeRequestMethod, normalizeRetryOptions} from '../utils/normalize.js';
@@ -73,7 +73,7 @@ export class Ky {
 			// eslint-disable-next-line unicorn/prevent-abbreviations
 			const textSearchParams = typeof this._options.searchParams === 'string' ?
 				this._options.searchParams.replace(/^\?/, '') :
-				new URLSearchParams(this._options.searchParams).toString();
+				new URLSearchParams(this._options.searchParams as unknown as SearchParamsInit).toString();
 			// eslint-disable-next-line unicorn/prevent-abbreviations
 			const searchParams = '?' + textSearchParams;
 			const url = this.request.url.replace(/(?:\?.*?)?(?=#|$)/, searchParams);

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -2,7 +2,11 @@ import type {LiteralUnion, Required} from './common.js';
 import type {Hooks} from './hooks.js';
 import type {RetryOptions} from './retry.js';
 
+// eslint-disable-next-line unicorn/prevent-abbreviations
 export type SearchParamsInit = string | string[][] | Record<string, string> | URLSearchParams | undefined;
+
+// eslint-disable-next-line unicorn/prevent-abbreviations
+export type SearchParamsOption = SearchParamsInit | Record<string, string | number | boolean> | Array<Array<string | number | boolean>>;
 
 export type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
 
@@ -101,7 +105,7 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 
 	Accepts any value supported by [`URLSearchParams()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams).
 	*/
-	searchParams?: SearchParamsInit | Record<string, string | number | boolean> | Array<Array<string | number | boolean>>;
+	searchParams?: SearchParamsOption;
 
 	/**
 	A prefix to prepend to the `input` URL when making the request. It can be any valid URL, either relative or absolute. A trailing slash `/` is optional and will be added automatically, if needed, when it is joined with `input`. Only takes effect when `input` is a string. The `input` argument cannot start with a slash `/` when using this option.

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -2,6 +2,8 @@ import type {LiteralUnion, Required} from './common.js';
 import type {Hooks} from './hooks.js';
 import type {RetryOptions} from './retry.js';
 
+export type SearchParamsInit = string | string[][] | Record<string, string> | URLSearchParams | undefined;
+
 export type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
 
 export type Input = string | URL | Request;
@@ -99,7 +101,7 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 
 	Accepts any value supported by [`URLSearchParams()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams).
 	*/
-	searchParams?: string[][] | Record<string, string> | string | URLSearchParams;
+	searchParams?: SearchParamsInit | Record<string, string | number | boolean> | Array<Array<string | number | boolean>>;
 
 	/**
 	A prefix to prepend to the `input` URL when making the request. It can be any valid URL, either relative or absolute. A trailing slash `/` is optional and will be added automatically, if needed, when it is joined with `input`. Only takes effect when `input` is a string. The `input` argument cannot start with a slash `/` when using this option.


### PR DESCRIPTION
I narrowed the type to fix a TypeScript error when the option was passed to the URLSearchParams constructor, but obviously it was a mistake as we don't want any breaking changes. We might want to reconsider in the future to be more compliant with the official types.

I've added a manual `as` to the constructor as a fix.

---

Fixes #343