### PR TITLE
Fix missing hook method types for TypeScript

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -28,6 +28,6 @@ const ky = createInstance();
 export default ky;
 
 export {Options};
-export {BeforeRequestHook, BeforeRetryHook, AfterResponseHook} from './types/hooks';
+export {BeforeRequestHook, BeforeRetryHook, AfterResponseHook} from './types/hooks.js';
 export {HTTPError} from './errors/HTTPError.js';
 export {TimeoutError} from './errors/TimeoutError.js';

--- a/source/index.ts
+++ b/source/index.ts
@@ -28,8 +28,6 @@ const ky = createInstance();
 export default ky;
 
 export {Options};
-
-export {AfterResponseHook, BeforeRequestHook, BeforeRetryHook} from './types/hooks';
-
+export {BeforeRequestHook, BeforeRetryHook, AfterResponseHook} from './types/hooks';
 export {HTTPError} from './errors/HTTPError.js';
 export {TimeoutError} from './errors/TimeoutError.js';

--- a/source/index.ts
+++ b/source/index.ts
@@ -29,5 +29,7 @@ export default ky;
 
 export {Options};
 
+export {AfterResponseHook, BeforeRequestHook, BeforeRetryHook} from './types/hooks';
+
 export {HTTPError} from './errors/HTTPError.js';
 export {TimeoutError} from './errors/TimeoutError.js';


### PR DESCRIPTION
Since version 0.28 the types exported by ky seem to have been reduced. Our codebase relies on ky hooks and we used to be able to import the hook method types from ky in TypeScript.

```typescript
import { AfterResponseHook, BeforeRequestHook } from 'ky';
```

This PR adds the missing exports for the hook methods back to the index including the new retry hook method.