### PR TITLE
Add `avoidCloningResponse` option (useful for large responses)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -303,6 +303,17 @@ Throw an `HTTPError` when, after following redirects, the response has a non-2xx
 
 Setting this to `false` may be useful if you are checking for resource availability and are expecting error responses.
 
+
+##### avoidCloningResponse
+
+Type: `boolean`\
+Default: `false`
+
+Don't clone response before `hooks.afterResponse`, `onDownloadProgress`, and method shortcuts.
+
+Useful to reduce browser memory consumption when fetching large responses. And in NodeJS, node-fetch doesn't get stuck if response is larger than highWaterMark.
+
+
 ##### onDownloadProgress
 
 Type: `Function`

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -178,6 +178,15 @@ export interface Options extends Omit<RequestInit, 'headers'> {
 	throwHttpErrors?: boolean;
 
 	/**
+	Don't clone response before `hooks.afterResponse`, `onDownloadProgress`, and method shortcuts.
+
+	Useful to reduce browser memory consumption when fetching large responses. And in NodeJS, node-fetch doesn't get stuck if response is larger than highWaterMark.
+
+	@default false
+	*/
+	avoidCloningResponse?: boolean;
+
+	/**
 	Download progress event handler.
 
 	@param chunk - Note: It's empty for the first call.


### PR DESCRIPTION
This mitigates recurring issues (https://github.com/sindresorhus/ky/issues/135, https://github.com/sindresorhus/ky/issues/31, https://github.com/sindresorhus/ky-universal/issues/18, https://github.com/sindresorhus/ky-universal/issues/8) caused by node-fetch clone limitations. Included test reproduces large responses getting stuck by default.

##### avoidCloningResponse

Type: `boolean`\
Default: `false`

Don't clone response before `hooks.afterResponse`, `onDownloadProgress`, and method shortcuts.

Useful to reduce browser memory consumption when fetching large responses. And in NodeJS, node-fetch doesn't get stuck if response is larger than highWaterMark.
