### PR TITLE
Update instructions for use without a bundler

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -537,11 +537,11 @@ Either use a test runner that can run in the browser, like Mocha, or use [AVA](h
 
 #### How do I use this without a bundler like Webpack?
 
-Upload the [`index.js`](index.js) file in this repo somewhere, for example, to your website server, or use a CDN version. Then import the file.
+Make sure your code is running as an ES module, for example by using a `<script type="module">` tag in your HTML document. Then Ky can be imported directly by that module without a bundler or other tools.
 
 ```html
 <script type="module">
-import ky from 'https://cdn.jsdelivr.net/npm/ky@latest/index.js';
+import ky from 'https://unpkg.com/ky/distribution/index.js';
 
 const json = await ky('https://jsonplaceholder.typicode.com/todos/1').json();
 

--- a/readme.md
+++ b/readme.md
@@ -537,7 +537,7 @@ Either use a test runner that can run in the browser, like Mocha, or use [AVA](h
 
 #### How do I use this without a bundler like Webpack?
 
-Make sure your code is running as an ES module, for example by using a `<script type="module">` tag in your HTML document. Then Ky can be imported directly by that module without a bundler or other tools.
+Make sure your code is running as a JavaScript module (ESM), for example by using a `<script type="module">` tag in your HTML document. Then Ky can be imported directly by that module without a bundler or other tools.
 
 ```html
 <script type="module">


### PR DESCRIPTION
This PR aims to fix the usage instructions and CDN import URL for those without a bundler, which PR #330 broke.

CDN users need to import `distribution/index.js` instead of `index.js`.

I also changed the CDN host from jsdelivr to unpkg, which isn't strictly necessary so long as the path is updated, but jsdelivr seems to be buggy. It's incorrectly caching `index.js` from previous versions and returning it, even though that file doesn't exist anymore.