### PR TITLE
Fix broken anchor link in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,7 @@ This hook enables you to modify the request right before retry. Ky will make no 
 
 If the request received a response, the error will be of type `HTTPError` and the `Response` object will be available at `error.response`. Be aware that some types of errors, such as network errors, inherently mean that a response was not received. In that case, the error will not be an instance of `HTTPError`.
 
-You can prevent Ky from retrying the request by throwing an error. Ky will not handle it in any way and the error will be propagated to the request initiator. The rest of the `beforeRetry` hooks will not be called in this case. Alternatively, you can return the [`ky.stop`](#ky.stop) symbol to do the same thing but without propagating an error (this has some limitations, see `ky.stop` docs for details).
+You can prevent Ky from retrying the request by throwing an error. Ky will not handle it in any way and the error will be propagated to the request initiator. The rest of the `beforeRetry` hooks will not be called in this case. Alternatively, you can return the [`ky.stop`](#kystop) symbol to do the same thing but without propagating an error (this has some limitations, see `ky.stop` docs for details).
 
 ```js
 import ky from 'ky';


### PR DESCRIPTION
Small nitpick, but the way GitHub markdown anchor tags work is that they ignore punctuation.

The correct url is https://github.com/sindresorhus/ky#kystop