### PR TITLE
Allow setting a custom content-type header for JSON requests

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -93,7 +93,7 @@ export class Ky {
 		if (this._options.json !== undefined) {
 			this._options.body = JSON.stringify(this._options.json);
 			this.request = new globalThis.Request(this.request, {body: this._options.body});
-			if (this._options.headers === undefined) {
+			if (!this.request.headers.has('content-type')) {
 				this.request.headers.set('content-type', 'application/json');
 			}
 		}

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -92,8 +92,10 @@ export class Ky {
 
 		if (this._options.json !== undefined) {
 			this._options.body = JSON.stringify(this._options.json);
-			this.request.headers.set('content-type', 'application/json');
 			this.request = new globalThis.Request(this.request, {body: this._options.body});
+			if (this._options.headers === undefined) {
+				this.request.headers.set('content-type', 'application/json');
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #369

if we have json data and
a header option is explicitly set
ky now overrides the default application/json header
with the header set by the user