### PR TITLE
Export KyInstance

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -27,6 +27,8 @@ const ky = createInstance();
 
 export default ky;
 
+export type {KyInterface};
+
 export {
 	Options,
 	NormalizedOptions,


### PR DESCRIPTION
To avoid using `typeof ky`, we can use the `KyInstance` type.