### PR TITLE
Fix types for TypeScript 4.4

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -234,7 +234,7 @@ export class Ky {
 					const hookResult = await hook({
 						request: this.request,
 						options: (this._options as unknown) as NormalizedOptions,
-						error,
+						error: error as Error,
 						retryCount: this._retryCount
 					});
 

--- a/source/types/hooks.ts
+++ b/source/types/hooks.ts
@@ -9,7 +9,7 @@ export type BeforeRequestHook = (
 export type BeforeRetryState = {
 	request: Request;
 	options: NormalizedOptions;
-	error: unknown;
+	error: Error;
 	retryCount: number;
 };
 export type BeforeRetryHook = (options: BeforeRetryState) => typeof stop | void | Promise<typeof stop | void>;


### PR DESCRIPTION
The catch error type is `unknown` instead of `any` with Typescript 4.4. https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables