### PR TITLE
add error exception on `ky.json()`

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -1,4 +1,4 @@
-import {HTTPError} from '../errors/HTTPError.js';
+import {HTTPError, ResponseError} from '../errors/HTTPError.js';
 import {TimeoutError} from '../errors/TimeoutError.js';
 import type {Hooks} from '../types/hooks.js';
 import type {Input, InternalOptions, NormalizedOptions, Options, SearchParamsInit} from '../types/options.js';
@@ -70,6 +70,17 @@ export class Ky {
 				const response = (await result).clone();
 
 				if (type === 'json') {
+					if (!response.ok) {
+						// eslint-disable-next-line @typescript-eslint/no-throw-literal
+						throw new ResponseError({
+							ok: response.ok,
+							response: await response.json(),
+							stackTrace: response,
+							status: response.status,
+							statusText: response.statusText,
+						});
+					}
+
 					if (response.status === 204) {
 						return '';
 					}

--- a/source/errors/HTTPError.ts
+++ b/source/errors/HTTPError.ts
@@ -20,3 +20,19 @@ export class HTTPError extends Error {
 		this.options = options;
 	}
 }
+
+export class ResponseError  {
+	public ok: boolean;
+	public response: Record<string, unknown>;
+	public stackTrace: Response;
+	public status: number;
+	public statusText: string;
+
+	constructor(errorsParameter: ResponseError) {
+		this.ok = errorsParameter.ok;
+		this.response = errorsParameter.response;
+		this.stackTrace = errorsParameter.stackTrace;
+		this.status = errorsParameter.status;
+		this.statusText = errorsParameter.statusText;
+	}
+}

--- a/source/index.ts
+++ b/source/index.ts
@@ -43,5 +43,5 @@ export {
 } from './types/hooks.js';
 
 export {ResponsePromise} from './types/response.js';
-export {HTTPError} from './errors/HTTPError.js';
+export {HTTPError, ResponseError} from './errors/HTTPError.js';
 export {TimeoutError} from './errors/TimeoutError.js';


### PR DESCRIPTION
I added error handling to the`ky.json()` method and it's an instance of `ResponseError`.
so that it can perform error checking on the catch block.
example
```typescript
import {ResponseError} from 'ky'
try {
 await ky.get('user').json()
} catch (error) {
 if (error instanceof ResponseError){
  // ...
 }
}
```