### PR TITLE
feat: export KyInstance as type

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -45,3 +45,4 @@ export {
 export {ResponsePromise} from './types/response.js';
 export {HTTPError} from './errors/HTTPError.js';
 export {TimeoutError} from './errors/TimeoutError.js';
+export type {KyInstance} from './types/ky.js';


### PR DESCRIPTION
sometimes you want to have a KyInstance declared somewhere, like:

```ts
import ky from 'ky'

class Requester {
  api: typeof KyInstance

  constructor() {
     this.api = ky.create({...});
  }
}
```


but sometimes you only want the type reference, not the actual `ky` module imported, so this:

```ts
import type { KyInstance } from 'ky'
```

might help

