### PR TITLE
Allow overriding `Content-Type` header for JSON requests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -527,19 +527,18 @@ const response = await ky.post(url, {body: searchParams});
 
 ### Setting a custom `Content-Type`
 
-Ky automatically sets an appropriate
-[Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type)
-header for each request based on the data in the request body. However, some
-APIs require custom, non-standard content types, such as
-`application/x-amz-json-1.1`. Using the
-`headers` option, you can manually override the content type.
+Ky automatically sets an appropriate [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) header for each request based on the data in the request body. However, some APIs require custom, non-standard content types, such as `application/x-amz-json-1.1`. Using the `headers` option, you can manually override the content type.
 
 ```js
-import ky from "ky";
+import ky from 'ky';
 
-const json = await ky.post("https://example.com", {
-  headers: { "content-type": "application/x-amz-json-1.1" },
-  json: { foo: true },
+const json = await ky.post('https://example.com', {
+	headers: {
+		'content-type': 'application/json'
+	}
+	json: {
+		foo: true
+	},
 }).json();
 
 console.log(json);

--- a/readme.md
+++ b/readme.md
@@ -525,6 +525,27 @@ searchParams.set('drink', 'icetea');
 const response = await ky.post(url, {body: searchParams});
 ```
 
+### Setting a custom `Content-Type`
+
+Ky automatically sets an appropriate
+[Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type)
+header for each request based on the data in the request body. However, some
+APIs require custom, non-standard content types, such as
+`application/x-amz-json-1.1`. Using the
+`headers` option, you can manually override the content type.
+
+```js
+import ky from "ky";
+
+const json = await ky.post("https://example.com", {
+  headers: { "content-type": "application/x-amz-json-1.1" },
+  json: { foo: true },
+}).json();
+
+console.log(json);
+//=> `{data: '🦄'}`
+```
+
 ### Cancellation
 
 Fetch (and hence Ky) has built-in support for request cancellation through the [`AbortController` API](https://developer.mozilla.org/en-US/docs/Web/API/AbortController). [Read more.](https://developers.google.com/web/updates/2017/09/abortable-fetch)

--- a/readme.md
+++ b/readme.md
@@ -527,7 +527,7 @@ const response = await ky.post(url, {body: searchParams});
 
 ### Setting a custom `Content-Type`
 
-Ky automatically sets an appropriate [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) header for each request based on the data in the request body. However, some APIs require custom, non-standard content types, such as `application/x-amz-json-1.1`. Using the `headers` option, you can manually override the content type.
+Ky automatically sets an appropriate [`Content-Type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) header for each request based on the data in the request body. However, some APIs require custom, non-standard content types, such as `application/x-amz-json-1.1`. Using the `headers` option, you can manually override the content type.
 
 ```js
 import ky from 'ky';

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -301,12 +301,12 @@ export class Ky {
 						}
 
 						if (onDownloadProgress) {
-							transferredBytes += value!.byteLength;
+							transferredBytes += value.byteLength;
 							const percent = totalBytes === 0 ? 0 : transferredBytes / totalBytes;
-							onDownloadProgress({percent, transferredBytes, totalBytes}, value!);
+							onDownloadProgress({percent, transferredBytes, totalBytes}, value);
 						}
 
-						controller.enqueue(value!);
+						controller.enqueue(value);
 						await read();
 					}
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -176,7 +176,7 @@ export class Ky {
 
 		if (this._options.json !== undefined) {
 			this._options.body = JSON.stringify(this._options.json);
-			this.request.headers.set('content-type', 'application/json');
+			this.request.headers.set('content-type', this._options.headers.get('content-type') ?? 'application/json');
 			this.request = new globalThis.Request(this.request, {body: this._options.body});
 		}
 	}

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -228,6 +228,7 @@ export type InternalOptions = Required<
 Omit<Options, 'hooks' | 'retry'>,
 'credentials' | 'fetch' | 'prefixUrl' | 'timeout'
 > & {
+	headers: Required<Headers>;
 	hooks: Required<Hooks>;
 	retry: Required<RetryOptions>;
 	prefixUrl: string;

--- a/test/headers.ts
+++ b/test/headers.ts
@@ -149,6 +149,24 @@ test('sets `content-length` to `0` when requesting PUT with empty body', async t
 	t.is(headers['content-length'], '0');
 });
 
+test('json manual `content-type` header', async t => {
+	const server = await createHttpTestServer();
+	server.post('/', echoHeaders);
+
+	const headers = await ky
+		.post(server.url, {
+			headers: {
+				'content-type': 'custom',
+			},
+			json: {
+				foo: true,
+			},
+		})
+		.json<IncomingHttpHeaders>();
+
+	t.is(headers['content-type'], 'custom');
+});
+
 test('form-data manual `content-type` header', async t => {
 	const server = await createHttpTestServer();
 	server.post('/', echoHeaders);


### PR DESCRIPTION
Closes #369

This PR adds logic to ensure that `options.headers` takes precedence over our own default for the `Content-Type` header when the `json` option is used. This allows the user to send a JSON request with a content type other than `application/json`.