### PR TITLE
Export BeforeRetryState from types/hooks

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -39,6 +39,7 @@ export {
 	Hooks,
 	BeforeRequestHook,
 	BeforeRetryHook,
+	BeforeRetryState,
 	BeforeErrorHook,
 	AfterResponseHook,
 } from './types/hooks.js';


### PR DESCRIPTION
The `BeforeRetryState` is the only type not exported from types/hooks.

**Background**
We are doing an upgrade to TS 4.7, in our code we were importing the `BeforeState` directly like this:
```ts
import { BeforeRetryState } from 'ky/distribution/types/hooks';
```
However after upgrading to TS 4.7, were can no longer can import the `BeforeRetryState` type directly:
<img width="542" alt="Screenshot 2022-06-23 at 12 17 58" src="https://user-images.githubusercontent.com/155505/175276705-cb719c9d-b50e-4f97-bc28-6f03d36931df.png">
And since it's not export the the following does not work either:
<img width="340" alt="Screenshot 2022-06-23 at 12 18 25" src="https://user-images.githubusercontent.com/155505/175276781-a32a9d2a-ec16-493a-b306-4b98852713b5.png">

So we want the `BeforeRetryState` too also be exported, so that we can import it directly e.g.:
```ts
import { BeforeRetryState } from 'ky';
```