### PR TITLE
Add retry.backoffLimit option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,7 @@ Default:
 - `methods`: `get` `put` `head` `delete` `options` `trace`
 - `statusCodes`: [`408`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) [`413`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413) [`429`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) [`500`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) [`502`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) [`503`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) [`504`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)
 - `maxRetryAfter`: `undefined`
+- `backoffLimit`: `undefined`
 
 An object representing `limit`, `methods`, `statusCodes` and `maxRetryAfter` fields for maximum retry count, allowed methods, allowed status codes and maximum [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) time.
 
@@ -176,7 +177,7 @@ If `retry` is a number, it will be used as `limit` and other defaults will remai
 
 If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is greater than `maxRetryAfter`, it will cancel the request.
 
-Delays between retries is calculated with the function `0.3 * (2 ** (retry - 1)) * 1000`, where `retry` is the attempt number (starts from 1).
+Delays between retries is calculated with the function `0.3 * (2 ** (retry - 1)) * 1000`, where `retry` is the attempt number (starts from 1). If `backoffLimit` is set, it will maximize the delay to that number so that it won't increase further after many retries.
 
 Retries are not triggered following a [timeout](#timeout).
 
@@ -187,7 +188,8 @@ const json = await ky('https://example.com', {
 	retry: {
 		limit: 10,
 		methods: ['get'],
-		statusCodes: [413]
+		statusCodes: [413],
+		backoffLimit: 3000
 	}
 }).json();
 ```

--- a/readme.md
+++ b/readme.md
@@ -177,8 +177,9 @@ If `retry` is a number, it will be used as `limit` and other defaults will remai
 
 If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is greater than `maxRetryAfter`, it will cancel the request.
 
-By default, the delay is calculated with `0.3 * (2 ** (attemptCount - 1)) * 1000`. The delay increases exponentially.
+The `backoffLimit` option is the upper limit of the delay per retry in milliseconds.
 To clamp the delay, set `backoffLimit` to 1000, for example.
+By default, the delay is calculated with `0.3 * (2 ** (attemptCount - 1)) * 1000`. The delay increases exponentially.
 
 Retries are not triggered following a [timeout](#timeout).
 

--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,8 @@ If `retry` is a number, it will be used as `limit` and other defaults will remai
 
 If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is greater than `maxRetryAfter`, it will cancel the request.
 
-Delays between retries is calculated with the function `0.3 * (2 ** (retry - 1)) * 1000`, where `retry` is the attempt number (starts from 1). If `backoffLimit` is set, it will maximize the delay to that number so that it won't increase further after many retries.
+By default, the delay is calculated with `0.3 * (2 ** (attemptCount - 1)) * 1000`. The delay increases exponentially.
+To clamp the delay, set `backoffLimit` to 1000, for example.
 
 Retries are not triggered following a [timeout](#timeout).
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -226,7 +226,7 @@ export class Ky {
 			}
 
 			const BACKOFF_FACTOR = 0.3;
-			return BACKOFF_FACTOR * (2 ** (this._retryCount - 1)) * 1000;
+			return Math.min(this._options.retry.backoffLimit, BACKOFF_FACTOR * (2 ** (this._retryCount - 1)) * 1000);
 		}
 
 		return 0;

--- a/source/types/retry.ts
+++ b/source/types/retry.ts
@@ -35,14 +35,14 @@ export interface RetryOptions {
 	maxRetryAfter?: number;
 
 	/**
-	The upper limit of the `computedValue`.
+	The upper limit of the delay per retry in ms.
 
-	By default, the computedValue is calculated in the following way:
+	By default, the delay is calculated in the following way:
 
 	0.3 * (2 ** (attemptCount - 1)) * 1000
 
 	The delay increases exponentially.
 	In order to prevent this, you can set this value to a fixed value, such as 1000.
-	 */
+	*/
 	backoffLimit?: number;
 }

--- a/source/types/retry.ts
+++ b/source/types/retry.ts
@@ -33,4 +33,16 @@ export interface RetryOptions {
 	@default Infinity
 	*/
 	maxRetryAfter?: number;
+
+	/**
+	The upper limit of the `computedValue`.
+
+	By default, the computedValue is calculated in the following way:
+
+	0.3 * (2 ** (attemptCount - 1)) * 1000
+
+	The delay increases exponentially.
+	In order to prevent this, you can set this value to a fixed value, such as 1000.
+	 */
+	backoffLimit?: number;
 }

--- a/source/types/retry.ts
+++ b/source/types/retry.ts
@@ -35,13 +35,16 @@ export interface RetryOptions {
 	maxRetryAfter?: number;
 
 	/**
-	The upper limit of the delay per retry in ms.
+	The upper limit of the delay per retry in milliseconds.
 
 	By default, the delay is calculated in the following way:
 
+	```
 	0.3 * (2 ** (attemptCount - 1)) * 1000
+	```
 
 	The delay increases exponentially.
+
 	In order to prevent this, you can set this value to a fixed value, such as 1000.
 	*/
 	backoffLimit?: number;

--- a/source/types/retry.ts
+++ b/source/types/retry.ts
@@ -45,7 +45,7 @@ export interface RetryOptions {
 
 	The delay increases exponentially.
 
-	In order to prevent this, you can set this value to a fixed value, such as 1000.
+  To clamp the delay, set `backoffLimit` to 1000, for example.
 	*/
 	backoffLimit?: number;
 }

--- a/source/types/retry.ts
+++ b/source/types/retry.ts
@@ -36,6 +36,7 @@ export interface RetryOptions {
 
 	/**
 	The upper limit of the delay per retry in milliseconds.
+	To clamp the delay, set `backoffLimit` to 1000, for example.
 
 	By default, the delay is calculated in the following way:
 
@@ -45,7 +46,7 @@ export interface RetryOptions {
 
 	The delay increases exponentially.
 
-  To clamp the delay, set `backoffLimit` to 1000, for example.
+	@default Infinity
 	*/
 	backoffLimit?: number;
 }

--- a/source/utils/normalize.ts
+++ b/source/utils/normalize.ts
@@ -17,6 +17,7 @@ const defaultRetryOptions: Required<RetryOptions> = {
 	statusCodes: retryStatusCodes,
 	afterStatusCodes: retryAfterStatusCodes,
 	maxRetryAfter: Number.POSITIVE_INFINITY,
+	backoffLimit: Number.POSITIVE_INFINITY,
 };
 
 export const normalizeRetryOptions = (retry: number | RetryOptions = {}): Required<RetryOptions> => {

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -444,7 +444,7 @@ test('throws when retry.statusCodes is not an array', async t => {
 });
 
 test('respect maximum backoff', async t => {
-	const retryCount = 6;
+	const retryCount = 5;
 	let requestCount = 0;
 
 	const server = await createHttpTestServer();
@@ -466,11 +466,11 @@ test('respect maximum backoff', async t => {
 		const measurements = items.getEntries();
 
 		const duration = measurements[0].duration ?? Number.NaN;
-		const expectedDuration = {default: 300 + 600 + 1200 + 2400 + 4800, custom: 300 + 600 + 1000 + 1000 + 1000}[measurements[0].name] ?? Number.NaN;
+		const expectedDuration = {default: 300 + 600 + 1200 + 2400, custom: 300 + 600 + 1000 + 1000}[measurements[0].name] ?? Number.NaN;
 
 		t.true(Math.abs(duration - expectedDuration) < allowedOffset, `Duration of ${duration}ms is not close to expected duration ${expectedDuration}ms`); // Allow for 300ms difference
 
-		if(measurements[0].name === 'custom') {
+		if (measurements[0].name === 'custom') {
 			obs.disconnect();
 		}
 	});

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -479,11 +479,11 @@ test('respect maximum backoff', async t => {
 
 	const duration = measurements.at(0)?.duration ?? Number.NaN;
 	const expectedDuration = 300 + 600 + 1200 + 2400 + 4800;
-	t.true(Math.abs(duration - expectedDuration) < 100, `Duration of ${duration} is not close to expected duration ${expectedDuration}`); // Allow for 100ms difference
+	t.true(Math.abs(duration - expectedDuration) < 300, `Duration of ${duration} is not close to expected duration ${expectedDuration}`); // Allow for 300ms difference
 
 	const customDuration = measurements.at(1)?.duration ?? Number.NaN;
 	const expectedCustomDuration = 300 + 600 + 1000 + 1000 + 1000;
-	t.true(Math.abs(customDuration - expectedCustomDuration) < 100, `Duration of ${customDuration}ms is not close to expected duration ${expectedCustomDuration}ms`); // Allow for 100ms difference
+	t.true(Math.abs(customDuration - expectedCustomDuration) < 300, `Duration of ${customDuration}ms is not close to expected duration ${expectedCustomDuration}ms`); // Allow for 300ms difference
 
 	await server.close();
 });

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -469,6 +469,10 @@ test('respect maximum backoff', async t => {
 		const expectedDuration = {default: 300 + 600 + 1200 + 2400 + 4800, custom: 300 + 600 + 1000 + 1000 + 1000}[measurements[0].name] ?? Number.NaN;
 
 		t.true(Math.abs(duration - expectedDuration) < allowedOffset, `Duration of ${duration}ms is not close to expected duration ${expectedDuration}ms`); // Allow for 300ms difference
+
+		if(measurements[0].name === 'custom') {
+			obs.disconnect();
+		}
 	});
 	obs.observe({entryTypes: ['measure']});
 

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -1,5 +1,5 @@
+import {performance} from 'node:perf_hooks';
 import test from 'ava';
-import {performance} from 'perf_hooks';
 import ky from '../source/index.js';
 import {createHttpTestServer} from './helpers/create-http-test-server.js';
 

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import {performance} from 'perf_hooks';
 import ky from '../source/index.js';
 import {createHttpTestServer} from './helpers/create-http-test-server.js';
 


### PR DESCRIPTION
I saw in the source code that the retry backoff function is hardcoded and exponential. However, I wanted to customize it.
Fortunately I also found the open issue addressing this limitation.

To start simple, I added a `backoffLimit` so that you can cap the delay that is exponentially growing. After 5 or so retries the delay becomes so large that the user will give up anyway.
Setting the limit to for example 1000 in combination with 60 retries will change the behavior into polling for 1 minute (my use case).

I had some trouble testing the delay because the calculate function is private and I didn't find a way to extract this information from the `ky` instance or response.
So I did some perf measurements to test the delays.

If you are happy with the PR so far, I will implement the `calculateDelay` option too.

Fixes #389