### PR TITLE
Parse empty response bodies without throwing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ The `input` and `options` are the same as [`fetch`](https://developer.mozilla.or
 - The `credentials` option is `same-origin` by default, which is the default in the spec too, but not all browsers have caught up yet.
 - Adds some more options. See below.
 
-Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return an empty string if the response status is `204` instead of throwing a parse error due to an empty body.
+Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return an empty string if body is empty or the response status is `204` instead of throwing a parse error due to an empty body.
 
 ### ky.get(input, options?)
 ### ky.post(input, options?)

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -90,6 +90,11 @@ export class Ky {
 						return '';
 					}
 
+					const contentLength = response.headers.get('Content-Length');
+					if (contentLength === null || contentLength === '0') {
+						return '';
+					}
+
 					if (options.parseJson) {
 						return options.parseJson(await response.text());
 					}

--- a/source/types/ResponsePromise.ts
+++ b/source/types/ResponsePromise.ts
@@ -1,5 +1,5 @@
 /**
-Returns a `Response` object with `Body` methods added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return an empty string if the response status is `204` instead of throwing a parse error due to an empty body.
+Returns a `Response` object with `Body` methods added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return an empty string if body is empty or the response status is `204` instead of throwing a parse error due to an empty body.
 */
 import {KyResponse} from './response.js';
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -236,18 +236,32 @@ test('.json() with custom accept header', async t => {
 	await server.close();
 });
 
-test('.json() with 200 response and empty body', async t => {
+test('.json() with invalid JSON body', async t => {
+	const server = await createHttpTestServer();
+	server.get('/', async (request, response) => {
+		t.is(request.headers.accept, 'application/json');
+		response.end('not json');
+	});
+
+	await t.throwsAsync(ky.get(server.url).json(), {
+		message: /Unexpected token/,
+	});
+
+	await server.close();
+});
+
+test('.json() with empty body', async t => {
 	t.plan(2);
 
 	const server = await createHttpTestServer();
 	server.get('/', async (request, response) => {
 		t.is(request.headers.accept, 'application/json');
-		response.status(200).end();
+		response.end();
 	});
 
-	await t.throwsAsync(ky(server.url).json(), {
-		message: /Unexpected end of JSON input/,
-	});
+	const responseJson = await ky.get(server.url).json();
+
+	t.is(responseJson, '');
 
 	await server.close();
 });


### PR DESCRIPTION
## Summary
Following the discussion in this Issue( #415 ), I changed the `.json()` behavior.
When response body is empty, `.json()` now returns an empty string (`''`) instead of throwing an exception(`FetchError: Invalid JSON`).
>  I was thinking in terms of whether it's reasonable for a given status code to have an empty body. But I'm sure there are plenty of implementations out there that return an empty body with a 200 or other success codes. Maybe we should just allow that for convenience sake.
https://github.com/sindresorhus/ky/issues/415#issuecomment-1007626969

> When Content-Length is 0 or is missing, body must be returned as an empty string.
https://github.com/sindresorhus/ky/issues/415#issuecomment-1228718284



## Issues
Close #415 
Close #430 

## Test Cases
### Added
- json() with empty response body
- json() with Invalid JSON response body ( plain text )
### Removed
- .json() with 200 response and empty body