### PR TITLE
Don't return empty string for .json() if Transfer-Encoding is chunked

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -92,7 +92,8 @@ export class Ky {
 					}
 
 					const contentLength = response.headers.get('Content-Length');
-					if (contentLength === null || contentLength === '0') {
+					const transferEncoding = response.headers.get('Transfer-Encoding');
+					if ((contentLength === null || contentLength === '0') && transferEncoding !== 'chunked') {
 						return '';
 					}
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -236,6 +236,22 @@ test('.json() with custom accept header', async t => {
 	await server.close();
 });
 
+test('.json() when response is chunked', async t => {
+	const server = await createHttpTestServer();
+	server.get('/', async (request, response) => {
+		response.write('[');
+		response.write('"one",');
+		response.write('"two"');
+		response.end(']');
+	});
+
+	const responseJson = await ky.get(server.url).json();
+
+	t.deepEqual(responseJson, ['one', 'two']);
+
+	await server.close();
+});
+
 test('.json() with invalid JSON body', async t => {
 	const server = await createHttpTestServer();
 	server.get('/', async (request, response) => {


### PR DESCRIPTION
fixes sindresorhus/ky#463

Here is some relevant documentation about the `Transfer-Encoding` header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding , specifically when a `chunked` value is set for that header:

> `chunked`: Data is sent in a series of chunks. The [`Content-Length`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length) header **is omitted in this case** [...] [emphasis added]

This is in contradiction to an implicit assumption seemingly made in https://github.com/sindresorhus/ky/pull/459 that a `Content-Length` header will always be set to some non-zero value if there is content in the response body.

The logic change in this PR returns a blank string for `.json()` only if the `Content-Length` header is `'0'` or missing (per #459) **AND** if there is not a `Transfer-Encoding` header with a value of `chunked`.

The test added in this PR sets a `Transfer-Encoding: chunked` header (and omits a `Content-Length` header) via the following setup, which writes to the response in chunks rather than all at once:

```js
server.get('/', async (request, response) => {
  response.write('[');
  response.write('"one",');
  response.write('"two"');
  response.end(']');
});
```