### PR TITLE
Return empty string from json() if byteLength of cloned response is 0

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -91,9 +91,9 @@ export class Ky {
 						return '';
 					}
 
-					const contentLength = response.headers.get('Content-Length');
-					const transferEncoding = response.headers.get('Transfer-Encoding');
-					if ((contentLength === null || contentLength === '0') && transferEncoding !== 'chunked') {
+					const arrayBuffer = await response.clone().arrayBuffer();
+					const responseSize = arrayBuffer.byteLength;
+					if (responseSize === 0) {
 						return '';
 					}
 


### PR DESCRIPTION
fixes #463 (third attempt! #464 was merged but does not fully solve the problem; #465 was closed without merge)

Many, many thanks to @0f-0b for [pointing out](https://github.com/sindresorhus/ky/issues/463#issuecomment-1297395043) what seems sort of obvious in retrospect, that the best way to do this is probably to read the actual response body (or lack thereof), which is what this PR does, rather than trying to use the HTTP headers to figure out whether the response contains a body or not.

Well, maybe it's not so obvious, actually, because there _might_ be downsides to calling `response.clone()` with respect to processing speed and/or memory usage. (We have to clone the response (or, at least, do something special) because once we read the response body, we can't read it again. I got the idea to `clone()` from here: https://jakearchibald.com/2014/reading-responses/.) Frankly, I don't know if either or both of those (processing, memory) are significant concerns or not. Hopefully, though, this cloning is just a "shallow" cloning (especially since we aren't really doing much of anything with the clone, so it should be possible to use "copy on write" here, i.e. not actually copy anything, since we aren't writing to / modifying the cloned response).

I'm not adding any tests in this PR, because I think that the existing tests adequately cover this code/functionality already.

cc @lemonadern @Nickhoyer 