### PR TITLE
Update recommended CDN for Deno

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ npm install ky
 
 - [jsdelivr](https://www.jsdelivr.com/package/npm/ky)
 - [unpkg](https://unpkg.com/ky)
+- [esm.sh](https://esm.sh/ky)
 
 ## Usage
 
@@ -84,7 +85,7 @@ console.log(json);
 If you are using [Deno](https://github.com/denoland/deno), import Ky from a URL. For example, using a CDN:
 
 ```js
-import ky from 'https://cdn.skypack.dev/ky?dts';
+import ky from 'https://esm.sh/ky';
 ```
 
 ## API


### PR DESCRIPTION
The Skypack CDN recommended in the README does not seem to be well maintained, with the [service status page](https://status.skypack.dev/) being 404, so changed to use [esm.sh](https://esm.sh/).

> reference: https://github.com/skypackjs/skypack-cdn/issues/329

I think esm.sh is the best choice for migration since it has the same extensive Typescript type support as Skypack.