### PR TITLE
feat: Throw DomException with name AbortError

### DIFF
--- a/source/errors/DOMException.ts
+++ b/source/errors/DOMException.ts
@@ -1,4 +1,4 @@
-// DomException is supported on most modern browsers, and Node >= 17.
+// DOMException is supported on most modern browsers and Node.js 18+.
 // @see https://developer.mozilla.org/en-US/docs/Web/API/DOMException#browser_compatibility
 const isDomExceptionSupported = Boolean(globalThis.DOMException);
 
@@ -12,7 +12,7 @@ export function composeAbortError(signal?: AbortSignal) {
 		return new DOMException(signal?.reason ?? 'The operation was aborted.', 'AbortError');
 	}
 
-	// DomException not supported fallback to use of error and override name
+	// DOMException not supported. Fall back to use of error and override name.
 	const error = new Error(signal?.reason ?? 'The operation was aborted.');
 	error.name = 'AbortError';
 

--- a/source/errors/DOMException.ts
+++ b/source/errors/DOMException.ts
@@ -1,6 +1,6 @@
 // DomException is supported on most modern browsers, and Node >= 17.
 // @see https://developer.mozilla.org/en-US/docs/Web/API/DOMException#browser_compatibility
-const domExceptionSupported = Boolean(globalThis.DOMException);
+const isDomExceptionSupported = Boolean(globalThis.DOMException);
 
 // TODO: When targeting Node.js 18, use `signal.throwIfAborted()` (https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/throwIfAborted)
 export function composeAbortError(signal?: AbortSignal) {

--- a/source/errors/DOMException.ts
+++ b/source/errors/DOMException.ts
@@ -1,12 +1,18 @@
+// DomException is supported on most modern browsers, and Node >= 17.
+// @see https://developer.mozilla.org/en-US/docs/Web/API/DOMException#browser_compatibility
 const domExceptionSupported = Boolean(globalThis.DOMException);
 
-// When targeting Node.js 18, use `signal.throwIfAborted()` (https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/throwIfAborted)
+// TODO: When targeting Node.js 18, use `signal.throwIfAborted()` (https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/throwIfAborted)
 export function composeAbortError(signal?: AbortSignal) {
-	// Supported on most modern browsers, and from Node >= 17. (https://developer.mozilla.org/en-US/docs/Web/API/DOMException#browser_compatibility)
+	/*
+		NOTE: Use DomException with AbortError name as specified in MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort)
+		> When abort() is called, the fetch() promise rejects with an Error of type DOMException, with name AbortError.
+	 */
 	if (domExceptionSupported) {
 		return new DOMException(signal?.reason ?? 'The operation was aborted.', 'AbortError');
 	}
 
+	// DomException not supported fallback to use of error and override name
 	const error = new Error(signal?.reason ?? 'The operation was aborted.');
 	error.name = 'AbortError';
 

--- a/source/errors/DOMException.ts
+++ b/source/errors/DOMException.ts
@@ -8,7 +8,7 @@ export function composeAbortError(signal?: AbortSignal) {
 	NOTE: Use DomException with AbortError name as specified in MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort)
 	> When abort() is called, the fetch() promise rejects with an Error of type DOMException, with name AbortError.
 	*/
-	if (domExceptionSupported) {
+	if (isDomExceptionSupported) {
 		return new DOMException(signal?.reason ?? 'The operation was aborted.', 'AbortError');
 	}
 

--- a/source/errors/DOMException.ts
+++ b/source/errors/DOMException.ts
@@ -5,9 +5,9 @@ const domExceptionSupported = Boolean(globalThis.DOMException);
 // TODO: When targeting Node.js 18, use `signal.throwIfAborted()` (https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/throwIfAborted)
 export function composeAbortError(signal?: AbortSignal) {
 	/*
-		NOTE: Use DomException with AbortError name as specified in MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort)
-		> When abort() is called, the fetch() promise rejects with an Error of type DOMException, with name AbortError.
-	 */
+	NOTE: Use DomException with AbortError name as specified in MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort)
+	> When abort() is called, the fetch() promise rejects with an Error of type DOMException, with name AbortError.
+	*/
 	if (domExceptionSupported) {
 		return new DOMException(signal?.reason ?? 'The operation was aborted.', 'AbortError');
 	}

--- a/source/errors/DOMException.ts
+++ b/source/errors/DOMException.ts
@@ -1,8 +1,14 @@
-const DOMException = globalThis.DOMException ?? Error;
-
-export default DOMException;
+const domExceptionSupported = Boolean(globalThis.DOMException);
 
 // When targeting Node.js 18, use `signal.throwIfAborted()` (https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/throwIfAborted)
 export function composeAbortError(signal?: AbortSignal) {
-	return new DOMException(signal?.reason ?? 'The operation was aborted.');
+	// Supported on most modern browsers, and from Node >= 17. (https://developer.mozilla.org/en-US/docs/Web/API/DOMException#browser_compatibility)
+	if (domExceptionSupported) {
+		return new DOMException(signal?.reason ?? 'The operation was aborted.', 'AbortError');
+	}
+
+	const error = new Error(signal?.reason ?? 'The operation was aborted.');
+	error.name = 'AbortError';
+
+	return error;
 }

--- a/test/main.ts
+++ b/test/main.ts
@@ -595,7 +595,7 @@ test('throws DOMException/Error with name AbortError when aborted by user', asyn
 	const error = (await t.throwsAsync(response))!;
 
 	t.true(['DomException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
-	t.true(error.name === 'AbortError', `Expected AbortError, got ${error.name}`);
+	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
 });
 
 test('supports Request instance as input', async t => {

--- a/test/main.ts
+++ b/test/main.ts
@@ -582,7 +582,7 @@ test('ky.extend()', async t => {
 	await server.close();
 });
 
-test('throws DomException/Error with name AbortError when aborted by user', async t => {
+test('throws DOMException/Error with name AbortError when aborted by user', async t => {
 	const server = await createHttpTestServer();
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	server.get('/', () => {});

--- a/test/main.ts
+++ b/test/main.ts
@@ -594,7 +594,7 @@ test('throws DOMException/Error with name AbortError when aborted by user', asyn
 
 	const error = (await t.throwsAsync(response))!;
 
-	t.true(['DomException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
+	t.true(['DOMException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
 	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
 });
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -582,7 +582,7 @@ test('ky.extend()', async t => {
 	await server.close();
 });
 
-test('throws DOMException when aborted by user', async t => {
+test('throws DomException/Error with name AbortError when aborted by user', async t => {
 	const server = await createHttpTestServer();
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	server.get('/', () => {});
@@ -592,8 +592,10 @@ test('throws DOMException when aborted by user', async t => {
 	const response = ky(server.url, {signal});
 	abortController.abort();
 
-	const {name} = (await t.throwsAsync(response))!;
-	t.true(['DOMException', 'Error'].includes(name), `Expected DOMException or Error, got ${name}`);
+	const error = (await t.throwsAsync(response))!;
+
+	t.true(['DomException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${ error.constructor.name }`)
+	t.true(error.name === 'AbortError', `Expected AbortError, got ${error.name}`);
 });
 
 test('supports Request instance as input', async t => {

--- a/test/main.ts
+++ b/test/main.ts
@@ -594,7 +594,7 @@ test('throws DomException/Error with name AbortError when aborted by user', asyn
 
 	const error = (await t.throwsAsync(response))!;
 
-	t.true(['DomException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${ error.constructor.name }`)
+	t.true(['DomException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
 	t.true(error.name === 'AbortError', `Expected AbortError, got ${error.name}`);
 });
 


### PR DESCRIPTION
## Description
When throwing DomException it should provide `AbortError` name to the DomException constructor as specified in the MDN docs [here](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort)

![Screenshot 2023-01-11 at 15 49 58](https://user-images.githubusercontent.com/155505/211836956-edc26031-d3c8-4f64-be1f-00738c24af3b.png)

The PR also includes fallback to use of `Error` class where the `name` property is overridden.

This PR addresses and closes the following issue #470