### PR TITLE
Fix flaky browser tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
       matrix:
         node-version:
           - 14
+          - 16
+          - 18
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 16
           - 18
+          - 16
+          - 14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -32,11 +32,11 @@ const addKyScriptToPage = async (page: Page) => {
 	await page.waitForFunction(() => typeof window.ky === 'function');
 };
 
-let server:ExtendedHttpTestServer;
+let server: ExtendedHttpTestServer;
 test.beforeEach(async () => {
 	server = await createEsmTestServer();
-	server.use((_, res, next) => {
-		res.set("Connection", "close");
+	server.use((_, response, next) => {
+		response.set('Connection', 'close');
 		next();
 	});
 });

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -3,7 +3,7 @@ import busboy from 'busboy';
 import express from 'express';
 import {Page} from 'playwright-chromium';
 import ky from '../source/index.js';
-import {createHttpTestServer, HttpServerOptions} from './helpers/create-http-test-server.js';
+import {createHttpTestServer, ExtendedHttpTestServer, HttpServerOptions} from './helpers/create-http-test-server.js';
 import {parseRawBody} from './helpers/parse-body.js';
 import {withPage} from './helpers/with-page.js';
 
@@ -32,9 +32,20 @@ const addKyScriptToPage = async (page: Page) => {
 	await page.waitForFunction(() => typeof window.ky === 'function');
 };
 
-test('prefixUrl option', withPage, async (t: ExecutionContext, page: Page) => {
-	const server = await createEsmTestServer();
+let server:ExtendedHttpTestServer;
+test.beforeEach(async () => {
+	server = await createEsmTestServer();
+	server.use((_, res, next) => {
+		res.set("Connection", "close");
+		next();
+	});
+});
 
+test.afterEach(async () => {
+	await server.close();
+});
+
+test.serial('prefixUrl option', withPage, async (t: ExecutionContext, page: Page) => {
 	server.get('/', (_request, response) => {
 		response.end('zebra');
 	});
@@ -60,13 +71,9 @@ test('prefixUrl option', withPage, async (t: ExecutionContext, page: Page) => {
 	]), server.url);
 
 	t.deepEqual(results, ['rainbow', 'rainbow', 'rainbow', 'rainbow']);
-
-	await server.close();
 });
 
-test('aborting a request', withPage, async (t: ExecutionContext, page: Page) => {
-	const server = await createEsmTestServer();
-
+test.serial('aborting a request', withPage, async (t: ExecutionContext, page: Page) => {
 	server.get('/', (_request, response) => {
 		response.end('meow');
 	});
@@ -89,15 +96,12 @@ test('aborting a request', withPage, async (t: ExecutionContext, page: Page) => 
 
 	// TODO: When targeting Node.js 18, also assert that the error is a DOMException
 	t.is(error.split(': ')[1], '🦄');
-
-	await server.close();
 });
 
-test('should copy origin response info when using `onDownloadProgress`', withPage, async (t: ExecutionContext, page: Page) => {
+test.serial('should copy origin response info when using `onDownloadProgress`', withPage, async (t: ExecutionContext, page: Page) => {
 	const json = {hello: 'world'};
 	const status = 202;
 	const statusText = 'Accepted';
-	const server = await createEsmTestServer();
 	server.get('/', (_request, response) => {
 		response.end('meow');
 	});
@@ -127,13 +131,11 @@ test('should copy origin response info when using `onDownloadProgress`', withPag
 		statusText,
 		data: json,
 	});
-	await server.close();
 });
 
-test('should not copy response body with 204 status code when using `onDownloadProgress` ', withPage, async (t: ExecutionContext, page: Page) => {
+test.serial('should not copy response body with 204 status code when using `onDownloadProgress` ', withPage, async (t: ExecutionContext, page: Page) => {
 	const status = 204;
 	const statusText = 'No content';
-	const server = await createEsmTestServer();
 	server.get('/', (_request, response) => {
 		response.end('meow');
 	});
@@ -178,13 +180,9 @@ test('should not copy response body with 204 status code when using `onDownloadP
 		totalBytes: data.totalBytes,
 		transferredBytes: 0,
 	}]);
-
-	await server.close();
 });
 
-test('aborting a request with onDonwloadProgress', withPage, async (t: ExecutionContext, page: Page) => {
-	const server = await createEsmTestServer();
-
+test.serial('aborting a request with onDonwloadProgress', withPage, async (t: ExecutionContext, page: Page) => {
 	server.get('/', (_request, response) => {
 		response.end('meow');
 	});
@@ -214,16 +212,12 @@ test('aborting a request with onDonwloadProgress', withPage, async (t: Execution
 	}, server.url);
 	// This should be an AbortError like in the 'aborting a request' test, but there is a bug in Chromium
 	t.is(error, 'TypeError: Failed to fetch');
-
-	await server.close();
 });
 
-test(
+test.serial(
 	'throws TimeoutError even though it does not support AbortController',
 	withPage,
 	async (t: ExecutionContext, page: Page) => {
-		const server = await createEsmTestServer();
-
 		server.get('/', (_request, response) => {
 			response.end();
 		});
@@ -252,14 +246,10 @@ test(
 
 		t.is(error.message, 'TimeoutError: Request timed out');
 		t.is(error.request.url, `${server.url}/slow`);
-
-		await server.close();
 	},
 );
 
-test('onDownloadProgress works', withPage, async (t: ExecutionContext, page: Page) => {
-	const server = await createEsmTestServer();
-
+test.serial('onDownloadProgress works', withPage, async (t: ExecutionContext, page: Page) => {
 	server.get('/', (_request, response) => {
 		response.writeHead(200, {
 			'content-length': '4',
@@ -297,13 +287,9 @@ test('onDownloadProgress works', withPage, async (t: ExecutionContext, page: Pag
 		[{percent: 1, transferredBytes: 4, totalBytes: 4}, 'ow'],
 	]);
 	t.is(result.text, 'meow');
-
-	await server.close();
 });
 
-test('throws if onDownloadProgress is not a function', withPage, async (t: ExecutionContext, page: Page) => {
-	const server = await createEsmTestServer();
-
+test.serial('throws if onDownloadProgress is not a function', withPage, async (t: ExecutionContext, page: Page) => {
 	server.get('/', (_request, response) => {
 		response.end();
 	});
@@ -317,13 +303,9 @@ test('throws if onDownloadProgress is not a function', withPage, async (t: Execu
 		return request.catch(error_ => error_.toString());
 	}, server.url);
 	t.is(error, 'TypeError: The `onDownloadProgress` option must be a function');
-
-	await server.close();
 });
 
-test('throws if does not support ReadableStream', withPage, async (t: ExecutionContext, page: Page) => {
-	const server = await createEsmTestServer();
-
+test.serial('throws if does not support ReadableStream', withPage, async (t: ExecutionContext, page: Page) => {
 	server.get('/', (_request, response) => {
 		response.end();
 	});
@@ -338,14 +320,10 @@ test('throws if does not support ReadableStream', withPage, async (t: ExecutionC
 		return request.catch(error_ => error_.toString());
 	}, server.url);
 	t.is(error, 'Error: Streams are not supported in your environment. `ReadableStream` is missing.');
-
-	await server.close();
 });
 
-test('FormData with searchParams', withPage, async (t: ExecutionContext, page: Page) => {
+test.serial('FormData with searchParams', withPage, async (t: ExecutionContext, page: Page) => {
 	t.plan(3);
-
-	const server = await createEsmTestServer({bodyParser: false});
 
 	server.get('/', (_request, response) => {
 		response.end();
@@ -374,14 +352,10 @@ test('FormData with searchParams', withPage, async (t: ExecutionContext, page: P
 			body: formData,
 		});
 	}, server.url);
-
-	await server.close();
 });
 
-test('FormData with searchParams ("multipart/form-data" parser)', withPage, async (t: ExecutionContext, page: Page) => {
+test.serial('FormData with searchParams ("multipart/form-data" parser)', withPage, async (t: ExecutionContext, page: Page) => {
 	t.plan(3);
-
-	const server = await createEsmTestServer();
 
 	server.get('/', (_request, response) => {
 		response.end();
@@ -447,17 +421,13 @@ test('FormData with searchParams ("multipart/form-data" parser)', withPage, asyn
 			body: formData,
 		});
 	}, server.url);
-
-	await server.close();
 });
 
-test(
+test.serial(
 	'headers are preserved when input is a Request and there are searchParams in the options',
 	withPage,
 	async (t: ExecutionContext, page: Page) => {
 		t.plan(2);
-
-		const server = await createEsmTestServer();
 
 		server.get('/', (_request, response) => {
 			response.end();
@@ -483,17 +453,13 @@ test(
 				})
 				.text();
 		}, server.url);
-
-		await server.close();
 	},
 );
 
-test('retry with body', withPage, async (t: ExecutionContext, page: Page) => {
+test.serial('retry with body', withPage, async (t: ExecutionContext, page: Page) => {
 	t.plan(4);
 
 	let requestCount = 0;
-
-	const server = await createEsmTestServer();
 
 	server.get('/', (_request, response) => {
 		response.end('zebra');
@@ -518,6 +484,4 @@ test('retry with body', withPage, async (t: ExecutionContext, page: Page) => {
 	);
 
 	t.is(requestCount, 2);
-
-	await server.close();
 });

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -17,6 +17,10 @@ const DIST_DIR = new URL('../distribution', import.meta.url).toString();
 const createEsmTestServer = async (options?: HttpServerOptions) => {
 	const server = await createHttpTestServer(options);
 	server.use('/distribution', express.static(DIST_DIR.replace(/^file:\/\//, '')));
+	server.use((_, response, next) => {
+		response.set('Connection', 'close');
+		next();
+	});
 	return server;
 };
 
@@ -35,10 +39,6 @@ const addKyScriptToPage = async (page: Page) => {
 let server: ExtendedHttpTestServer;
 test.beforeEach(async () => {
 	server = await createEsmTestServer();
-	server.use((_, response, next) => {
-		response.set('Connection', 'close');
-		next();
-	});
 });
 
 test.afterEach(async () => {

--- a/test/helpers/with-page.ts
+++ b/test/helpers/with-page.ts
@@ -1,12 +1,12 @@
 import process from 'node:process';
-import type {ExecutionContext, UntitledMacro} from 'ava';
+import type {ExecutionContext, Implementation} from 'ava';
 import {chromium, Page} from 'playwright-chromium';
 
 type Run = (t: ExecutionContext, page: Page) => Promise<void>;
 
 const PWDEBUG = Boolean(process.env['PWDEBUG']);
 
-export const withPage: UntitledMacro<any[]> = async (t: ExecutionContext, run: Run): Promise<void> => {
+export const withPage: Implementation<any[]> = async (t: ExecutionContext, run: Run): Promise<void> => {
 	const browser = await chromium.launch({
 		devtools: PWDEBUG,
 	});


### PR DESCRIPTION
The browser tests were flaky due to the reason that the `server.close()` call was slow sometimes due to open connection kept alive, which is default server behaviour.  Resulting in false pending tests assertiions that are actually finished but never finish and times out due to that the server is not closed within the expected timeout.

## What's done
* Added middleware that ensures that the connections are closed after response is sent (@see stackoverflow [here](https://stackoverflow.com/a/13554590/620479))
* Added `beforeEach`  and `afterEach` methods that setups and closes server for each test.
* All the tests are also now serial which is needed since we only have one server that is setup and teardown per test as mentioned above (also playwright is not that good with parallell running browsers either way).
* Enabled the github workflow matrix to also run for node versions 16 and 18.
* Fixed import of `UntitledMacro` that has been renamed to `Implementation`.

## NOTES:
* Tried to avoid adding the `beforeEach` and `afterEach` methods that setups and closes the server. Unless done this way the browser tests  keep beeing flaky 🤷🏽 .