### PR TITLE
fix: check `Request` before executing

### DIFF
--- a/source/core/constants.ts
+++ b/source/core/constants.ts
@@ -5,8 +5,9 @@ export const supportsRequestStreams = (() => {
 	let duplexAccessed = false;
 	let hasContentType = false;
 	const supportsReadableStream = typeof globalThis.ReadableStream === 'function';
+	const supportsRequest = typeof globalThis.Request === 'function';
 
-	if (supportsReadableStream) {
+	if (supportsReadableStream && supportsRequest) {
 		hasContentType = new globalThis.Request('https://a.com', {
 			body: new globalThis.ReadableStream(),
 			method: 'POST',


### PR DESCRIPTION
```
~/Developer/open-source
❯ node -v
v18.14.0

~/Developer/open-source
❯ node --no-experimental-fetch
Welcome to Node.js v18.14.0.
Type ".help" for more information.
> ReadableStream
[class ReadableStream]
> Request
Uncaught ReferenceError: Request is not defined
>
```