### PR TITLE
importing index.ts in readme.md deno example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ console.log(json);
 If you are using [Deno](https://github.com/denoland/deno), import Ky from a URL. For example, using a CDN:
 
 ```js
-import ky from 'https://esm.sh/ky';
+import ky from "https://deno.land/x/ky/source/index.ts";
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ console.log(json);
 If you are using [Deno](https://github.com/denoland/deno), import Ky from a URL. For example, using a CDN:
 
 ```js
-import ky from "https://deno.land/x/ky/source/index.ts";
+import ky from 'https://deno.land/x/ky/source/index.ts';
 ```
 
 ## API


### PR DESCRIPTION
for deno I think it's better to use the more idiomatic index.ts export from https://deno.land