### PR TITLE
fix: replace placeholder a.com with unresolvable emtpy.invalid (RFC 2606)

### DIFF
--- a/source/core/constants.ts
+++ b/source/core/constants.ts
@@ -8,7 +8,7 @@ export const supportsRequestStreams = (() => {
 	const supportsRequest = typeof globalThis.Request === 'function';
 
 	if (supportsReadableStream && supportsRequest) {
-		hasContentType = new globalThis.Request('https://a.com', {
+		hasContentType = new globalThis.Request('https://empty.invalid', {
 			body: new globalThis.ReadableStream(),
 			method: 'POST',
 			// @ts-expect-error - Types are outdated.


### PR DESCRIPTION
This was added in 0b141f1725442039a439b683d32d42e9b9d52559 as a fix for #452.

This replaces the patched-in `a.com` with a domain which is reserved and guaranteed to not resolve to an actual address as per https://www.rfc-editor.org/rfc/rfc2606.