### PR TITLE
Export type KyInstance

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -48,3 +48,4 @@ export type {ResponsePromise} from './types/ResponsePromise.js';
 export type {KyResponse} from './types/response.js';
 export {HTTPError} from './errors/HTTPError.js';
 export {TimeoutError} from './errors/TimeoutError.js';
+export type {KyInstance};


### PR DESCRIPTION
Thanks for this great lib 🙏 

This is a small PR to export KyInstance to improve typescript support. 

This is especially useful when using `ky.create(...)` to init a ky instance with new defaults in a class constructor. Without KyInstance type being exported it's impossible to type a class property holding the ky instance.

```ts
class Foo {
    #kyClient:KyInstance // can't be typed without exporting KyInstance

    constructor() {
        this.#kyClient = ky.create({
            headers: { 'PRIVATE-TOKEN': 'XXXXXXX' }
        })
    }
 // etc...
}
```