### PR TITLE
Add retry.delay option to control the time between retries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -208,8 +208,7 @@ The `backoffLimit` option is the upper limit of the delay per retry in milliseco
 To clamp the delay, set `backoffLimit` to 1000, for example.
 By default, the delay is calculated with `0.3 * (2 ** (attemptCount - 1)) * 1000`. The delay increases exponentially.
 
-The `delay` option can be used to change how the delay between retries is calculated. The function receives one parameter,
-the attempt count, starting at `1`.
+The `delay` option can be used to change how the delay between retries is calculated. The function receives one parameter, the attempt count, starting at `1`.
 
 Retries are not triggered following a [timeout](#timeout).
 

--- a/readme.md
+++ b/readme.md
@@ -196,6 +196,7 @@ Default:
 - `statusCodes`: [`408`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) [`413`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413) [`429`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) [`500`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) [`502`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) [`503`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) [`504`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)
 - `maxRetryAfter`: `undefined`
 - `backoffLimit`: `undefined`
+- `delay`: `attemptCount => 0.3 * (2 ** (attemptCount - 1)) * 1000`
 
 An object representing `limit`, `methods`, `statusCodes` and `maxRetryAfter` fields for maximum retry count, allowed methods, allowed status codes and maximum [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) time.
 
@@ -206,6 +207,9 @@ If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Re
 The `backoffLimit` option is the upper limit of the delay per retry in milliseconds.
 To clamp the delay, set `backoffLimit` to 1000, for example.
 By default, the delay is calculated with `0.3 * (2 ** (attemptCount - 1)) * 1000`. The delay increases exponentially.
+
+The `delay` option can be used to change how the delay between retries is calculated. The function receives one parameter,
+the attempt count, starting at `1`.
 
 Retries are not triggered following a [timeout](#timeout).
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -234,8 +234,8 @@ export class Ky {
 				}
 			}
 
-			const BACKOFF_FACTOR = 0.3;
-			return Math.min(this._options.retry.backoffLimit, BACKOFF_FACTOR * (2 ** (this._retryCount - 1)) * 1000);
+			const retryDelay = this._options.retry.delay(this._retryCount);
+			return Math.min(this._options.retry.backoffLimit, retryDelay);
 		}
 
 		return 0;

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -138,7 +138,7 @@ export interface Options extends Omit<RequestInit, 'headers'> { // eslint-disabl
 
 	If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is greater than `maxRetryAfter`, it will cancel the request.
 
-	Delays between retries is calculated with the function `0.3 * (2 ** (retry - 1)) * 1000`, where `retry` is the attempt number (starts from 1).
+	By default delays between retries are calculated with the function `0.3 * (2 ** (retry - 1)) * 1000`, where `retry` is the attempt number (starts from 1), however this can be changed by passing a `delay` function.
 
 	Retries are not triggered following a timeout.
 

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -138,7 +138,7 @@ export interface Options extends Omit<RequestInit, 'headers'> { // eslint-disabl
 
 	If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is greater than `maxRetryAfter`, it will cancel the request.
 
-	By default delays between retries are calculated with the function `0.3 * (2 ** (retry - 1)) * 1000`, where `retry` is the attempt number (starts from 1), however this can be changed by passing a `delay` function.
+	By default, delays between retries are calculated with the function `0.3 * (2 ** (attemptCount - 1)) * 1000`, where `attemptCount` is the attempt number (starts from 1), however this can be changed by passing a `delay` function.
 
 	Retries are not triggered following a timeout.
 

--- a/source/types/retry.ts
+++ b/source/types/retry.ts
@@ -49,4 +49,11 @@ export type RetryOptions = {
 	@default Infinity
 	*/
 	backoffLimit?: number;
+
+	/**
+	A function to calculate the delay between retries given `attemptCount` (starts from 1).
+
+	@default attemptCount => 0.3 * (2 ** (attemptCount - 1)) * 1000
+	*/
+	delay?: (attemptCount: number) => number;
 };

--- a/source/utils/normalize.ts
+++ b/source/utils/normalize.ts
@@ -18,6 +18,7 @@ const defaultRetryOptions: Required<RetryOptions> = {
 	afterStatusCodes: retryAfterStatusCodes,
 	maxRetryAfter: Number.POSITIVE_INFINITY,
 	backoffLimit: Number.POSITIVE_INFINITY,
+	delay: attemptCount => 0.3 * (2 ** (attemptCount - 1)) * 1000,
 };
 
 export const normalizeRetryOptions = (retry: number | RetryOptions = {}): Required<RetryOptions> => {

--- a/test/helpers/with-performance-observer.ts
+++ b/test/helpers/with-performance-observer.ts
@@ -1,0 +1,42 @@
+import {performance, PerformanceObserver} from 'node:perf_hooks';
+import process from 'node:process';
+import type {ExecutionContext} from 'ava';
+
+type Arg = {
+	name: string;
+	expectedDuration: number;
+	t: ExecutionContext;
+	test: () => Promise<void>;
+};
+
+// We allow the tests to take more time on CI than locally, to reduce flakiness
+const allowedOffset = process.env.CI ? 1000 : 300;
+
+export async function withPerformanceObserver({
+	name,
+	expectedDuration,
+	t,
+	test,
+}: Arg) {
+	// Register observer that asserts on duration when a measurement is performed
+	const obs = new PerformanceObserver(items => {
+		const measurements = items.getEntries();
+
+		const duration = measurements[0].duration ?? Number.NaN;
+
+		t.true(
+			Math.abs(duration - expectedDuration) < allowedOffset,
+			`Duration of ${duration}ms is not close to expected duration ${expectedDuration}ms`,
+		);
+
+		obs.disconnect();
+	});
+	obs.observe({entryTypes: ['measure']});
+
+	// Start measuring
+	performance.mark(`start-${name}`);
+	await test();
+	performance.mark(`end-${name}`);
+
+	performance.measure(name, `start-${name}`, `end-${name}`);
+}

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -8,6 +8,7 @@ const fixture = 'fixture';
 const defaultRetryCount = 2;
 const retryAfterOn413 = 2;
 const lastTried413access = Date.now();
+
 // We allow the tests to take more time on CI than locally, to reduce flakiness
 const allowedOffset = process.env.CI ? 1000 : 300;
 

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -1,16 +1,12 @@
-import {performance, PerformanceObserver} from 'node:perf_hooks';
-import process from 'node:process';
 import test from 'ava';
 import ky from '../source/index.js';
 import {createHttpTestServer} from './helpers/create-http-test-server.js';
+import {withPerformanceObserver} from './helpers/with-performance-observer.js';
 
 const fixture = 'fixture';
 const defaultRetryCount = 2;
 const retryAfterOn413 = 2;
 const lastTried413access = Date.now();
-
-// We allow the tests to take more time on CI than locally, to reduce flakiness
-const allowedOffset = process.env.CI ? 1000 : 300;
 
 test('network error', async t => {
 	let requestCount = 0;
@@ -461,41 +457,31 @@ test('respect maximum backoff', async t => {
 		}
 	});
 
-	// Register observer that asserts on duration when a measurement is performed
-	const obs = new PerformanceObserver(items => {
-		const measurements = items.getEntries();
-
-		const duration = measurements[0].duration ?? Number.NaN;
-		const expectedDuration = {default: 300 + 600 + 1200 + 2400, custom: 300 + 600 + 1000 + 1000}[measurements[0].name] ?? Number.NaN;
-
-		t.true(Math.abs(duration - expectedDuration) < allowedOffset, `Duration of ${duration}ms is not close to expected duration ${expectedDuration}ms`); // Allow for 300ms difference
-
-		if (measurements[0].name === 'custom') {
-			obs.disconnect();
-		}
-	});
-	obs.observe({entryTypes: ['measure']});
-
-	// Start measuring
-	performance.mark('start');
-	t.is(await ky(server.url, {
-		retry: retryCount,
-	}).text(), fixture);
-	performance.mark('end');
-
-	performance.mark('start-custom');
-	requestCount = 0;
-	t.is(await ky(server.url, {
-		retry: {
-			limit: retryCount,
-			backoffLimit: 1000,
+	await withPerformanceObserver({
+		t,
+		name: 'default',
+		expectedDuration: 300 + 600 + 1200 + 2400,
+		async test() {
+			t.is(await ky(server.url, {
+				retry: retryCount,
+			}).text(), fixture);
 		},
-	}).text(), fixture);
+	});
 
-	performance.mark('end-custom');
-
-	performance.measure('default', 'start', 'end');
-	performance.measure('custom', 'start-custom', 'end-custom');
+	requestCount = 0;
+	await withPerformanceObserver({
+		t,
+		name: 'custom',
+		expectedDuration: 300 + 600 + 1000 + 1000,
+		async test() {
+			t.is(await ky(server.url, {
+				retry: {
+					limit: retryCount,
+					backoffLimit: 1000,
+				},
+			}).text(), fixture);
+		},
+	});
 
 	await server.close();
 });
@@ -515,30 +501,19 @@ test('respect custom retry.delay', async t => {
 		}
 	});
 
-	// Register observer that asserts on duration when a measurement is performed
-	const obs = new PerformanceObserver(items => {
-		const measurements = items.getEntries();
-
-		const duration = measurements[0].duration ?? Number.NaN;
-		const expectedDuration = 200 + 300 + 400 + 500;
-
-		t.true(Math.abs(duration - expectedDuration) < allowedOffset, `Duration of ${duration}ms is not close to expected duration ${expectedDuration}ms`);
-
-		obs.disconnect();
-	});
-	obs.observe({entryTypes: ['measure']});
-
-	// Start measuring
-	performance.mark('start');
-	t.is(await ky(server.url, {
-		retry: {
-			limit: retryCount,
-			delay: n => 100 * (n + 1),
+	await withPerformanceObserver({
+		t,
+		name: 'linear',
+		expectedDuration: 200 + 300 + 400 + 500,
+		async test() {
+			t.is(await ky(server.url, {
+				retry: {
+					limit: retryCount,
+					delay: n => 100 * (n + 1),
+				},
+			}).text(), fixture);
 		},
-	}).text(), fixture);
-	performance.mark('end');
-
-	performance.measure('linear', 'start', 'end');
+	});
 
 	await server.close();
 });


### PR DESCRIPTION
Related to option (2) to #509 

### Changes
- add `delay` function to `RetryOptions` object
- add test for using `delay`