### PR TITLE
Don't require custom fetch options to not be in Request to pass them explicitly

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -295,7 +295,7 @@ export class Ky {
 			}
 		}
 
-		const nonRequestOptions = findUnknownOptions(this.request, this._options);
+		const nonRequestOptions = findUnknownOptions(this._options);
 
 		if (this._options.timeout === false) {
 			return this._options.fetch(this.request.clone(), nonRequestOptions);

--- a/source/utils/options.ts
+++ b/source/utils/options.ts
@@ -1,13 +1,12 @@
 import {kyOptionKeys, requestOptionsRegistry} from '../core/constants.js';
 
 export const findUnknownOptions = (
-	request: Request,
 	options: Record<string, unknown>,
 ): Record<string, unknown> => {
 	const unknownOptions: Record<string, unknown> = {};
 
 	for (const key in options) {
-		if (!(key in requestOptionsRegistry) && !(key in kyOptionKeys) && !(key in request)) {
+		if (!(key in requestOptionsRegistry) && !(key in kyOptionKeys)) {
 			unknownOptions[key] = options[key];
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/ky/issues/541.

Since https://github.com/sindresorhus/ky/pull/540 already added explicit checks against the known keys of `RequestInit`, I don't think the `!(key in request)` check is still needed, and removing it fixes the issue mentioned.

I can try to add a test if the general idea seems reasonable - I think to do so, I would need to simulate what Next is doing with patching `Request` to have the `next` property.

