### PR TITLE
Make types compatible with both DOM and Node.js

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -175,7 +175,7 @@ export class Ky {
 			this._options.duplex = 'half';
 		}
 
-		this.request = new globalThis.Request(this._input as RequestInfo, this._options as RequestInit);
+		this.request = new globalThis.Request(this._input, this._options);
 
 		if (this._options.searchParams) {
 			// eslint-disable-next-line unicorn/prevent-abbreviations

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -22,7 +22,8 @@ export type DownloadProgress = {
 	totalBytes: number;
 };
 
-export type KyHeadersInit = HeadersInit | Record<string, string | undefined>;
+// Not HeadersInit directly because @types/node doesn't export it
+export type KyHeadersInit = NonNullable<RequestInit['headers']> | Record<string, string | undefined>;
 
 /**
 Custom Ky options
@@ -177,7 +178,7 @@ export type KyOptions = {
 	const json = await ky('https://example.com', {fetch}).json();
 	```
 	*/
-	fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+	fetch?: (input: Input, init?: RequestInit) => Promise<Response>;
 };
 
 /**
@@ -251,8 +252,8 @@ Normalized options passed to the `fetch` call and the `beforeRequest` hooks.
 */
 export interface NormalizedOptions extends RequestInit { // eslint-disable-line @typescript-eslint/consistent-type-definitions -- This must stay an interface so that it can be extended outside of Ky for use in `ky.create`.
 	// Extended from `RequestInit`, but ensured to be set (not optional).
-	method: RequestInit['method'];
-	credentials: RequestInit['credentials'];
+	method: NonNullable<RequestInit['method']>;
+	credentials: NonNullable<RequestInit['credentials']>;
 
 	// Extended from custom `KyOptions`, but ensured to be set (not optional).
 	retry: RetryOptions;

--- a/source/utils/merge.ts
+++ b/source/utils/merge.ts
@@ -12,9 +12,9 @@ export const validateAndMerge = (...sources: Array<Partial<Options> | undefined>
 };
 
 export const mergeHeaders = (source1: KyHeadersInit = {}, source2: KyHeadersInit = {}) => {
-	const result = new globalThis.Headers(source1 as HeadersInit);
+	const result = new globalThis.Headers(source1 as RequestInit['headers']);
 	const isHeadersInstance = source2 instanceof globalThis.Headers;
-	const source = new globalThis.Headers(source2 as HeadersInit);
+	const source = new globalThis.Headers(source2 as RequestInit['headers']);
 
 	for (const [key, value] of source.entries()) {
 		if ((isHeadersInstance && value === 'undefined') || value === undefined) {

--- a/test/headers.ts
+++ b/test/headers.ts
@@ -23,7 +23,7 @@ test.serial('works with nullish headers even in old browsers', async t => {
 	// so we check that Ky never does that and passes an empty object instead.
 	// See: https://github.com/sindresorhus/ky/issues/260
 	globalThis.Headers = class Headers extends OriginalHeaders {
-		constructor(headersInit?: HeadersInit | undefined) {
+		constructor(headersInit?: RequestInit['headers']) {
 			t.deepEqual(headersInit, {});
 			super(headersInit);
 		}


### PR DESCRIPTION
Otherwise TypeScript fails with `skipLibCheck: false`, `exactOptionalPropertyTypes: true` and no `DOM`:

```
Error: node_modules/ky/distribution/types/options.d.ts(226,18): error TS2430: Interface 'NormalizedOptions' incorrectly extends interface 'RequestInit'.
  Types of property 'credentials' are incompatible.
    Type 'RequestCredentials | undefined' is not assignable to type 'RequestCredentials'.
      Type 'undefined' is not assignable to type 'RequestCredentials'.
Error: node_modules/ky/distribution/types/options.d.ts(16,29): error TS2552: Cannot find name 'HeadersInit'. Did you mean 'KyHeadersInit'?
Error: node_modules/ky/distribution/types/options.d.ts(160,21): error TS2552: Cannot find name 'RequestInfo'. Did you mean 'RequestInit'?
Error: node_modules/ky/distribution/types/options.d.ts(226,18): error TS2430: Interface 'NormalizedOptions' incorrectly extends interface 'RequestInit'.
  Types of property 'method' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.
```

Would add a test, but it doesn't seem like there are any type tests. How do you want to go about this?