### PR TITLE
Fix #528 (retry count 1 less than retry limit)

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -208,7 +208,7 @@ export class Ky {
 	protected _calculateRetryDelay(error: unknown) {
 		this._retryCount++;
 
-		if (this._retryCount < this._options.retry.limit && !(error instanceof TimeoutError)) {
+		if (this._retryCount <= this._options.retry.limit && !(error instanceof TimeoutError)) {
 			if (error instanceof HTTPError) {
 				if (!this._options.retry.statusCodes.includes(error.response.status)) {
 					return 0;

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -479,7 +479,7 @@ browserTest('retry with body', [chromium, webkit], async (t: ExecutionContext, p
 		page.evaluate(async (url: string) => window.ky(`${url}/test`, {
 			body: 'foo',
 			method: 'PUT',
-			retry: 2,
+			retry: 1,
 		}), server.url),
 		{message: /HTTPError: Request failed with status code 502 Bad Gateway/},
 	);

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -427,7 +427,7 @@ test('beforeRetry hook is called even if the error has no response', async t => 
 
 	const text = await ky
 		.get(server.url, {
-			retry: 2,
+			retry: 1,
 			async fetch(request) {
 				if (requestCount === 0) {
 					requestCount++;
@@ -473,7 +473,7 @@ test('beforeRetry hook with parseJson and error.response.json()', async t => {
 
 	const json = await ky
 		.get(server.url, {
-			retry: 2,
+			retry: 1,
 			parseJson(text) {
 				t.is(text, 'text');
 				return {awesome: true};


### PR DESCRIPTION
Fixes #528 (actual retry count being 1 less than the specified retry limit).
This could be seen as a breaking change for projects using the +1 workaround.

The [main issue](https://github.com/sindresorhus/ky/blob/3cf50649ac2a9d5230ebcff94fa58b63a77781dc/source/core/Ky.ts#L209-L211) was `_retryCount` first being incremented, then being checked if it's less than `_options.retry.limit`, resulting in an off-by-one which is fixed with a less-or-equal comparison instead.

Re-enabled retry count test, and fixed other misconfigured tests which either explicitly failed or had silent bugs related to this. All tests pass with Node v18.18.0 (v18.18.2 breaks a number of tests, and Ava can't use custom loaders with v18.19 or v20+ making testing impossible).
EDIT: CI seems to fail since it doesn't extend `tsconfig.json` properly - I instead pointed it explicitly at `./node_modules/@sindresorhus/tsconfig/tsconfig.json` as a quickfix, but messing with the base config seems beyond the scope of this PR.