### PR TITLE
fix: Add a condition to verify that the `accept` of the request header starts with `'text'`

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -101,7 +101,7 @@ export class Ky {
 						return options.parseJson(await response.text());
 					}
 
-					if (response.headers.get('accept')?.startsWith('text')) {
+					if (ky.request.headers.get('accept')?.startsWith('text')) {
 						return response.text();
 					}
 				}

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -103,9 +103,9 @@ export class Ky {
 
 					// If error causes when call JSON.parse
 					try {
-						return response[type]();
+						return (await response.json());
 					} catch {
-						return await response.text()
+						return response.text();
 					}
 				}
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -101,10 +101,7 @@ export class Ky {
 						return options.parseJson(await response.text());
 					}
 
-					// If error causes when call JSON.parse
-					try {
-						return (await response.json());
-					} catch {
+					if (response.headers.get('accept')?.startsWith('text')) {
 						return response.text();
 					}
 				}

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -100,6 +100,13 @@ export class Ky {
 					if (options.parseJson) {
 						return options.parseJson(await response.text());
 					}
+
+					// If error causes when call JSON.parse
+					try {
+						return response[type]();
+					} catch {
+						return await response.text()
+					}
 				}
 
 				return response[type]();

--- a/test/main.ts
+++ b/test/main.ts
@@ -266,6 +266,23 @@ test('.json() with invalid JSON body', async t => {
 	await server.close();
 });
 
+test('.json() with invalid JSON body and accept starts with text', async t => {
+	const server = await createHttpTestServer();
+	server.get('/', async (request, response) => {
+		t.is(request.headers.accept, 'text/plain');
+		response.end('not json');
+	});
+
+	// I think the code is a bit weird in this situation.
+	const responseJson = await ky.get(server.url).json();
+	const responseText = await ky.get(server.url).text();
+
+	t.deepEqual(responseJson, 'not json');
+	t.deepEqual(responseText, 'not json');
+
+	await server.close();
+});
+
 test('.json() with empty body', async t => {
 	t.plan(2);
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -277,8 +277,8 @@ test('.json() with invalid JSON body and accept starts with text', async t => {
 	const responseJson = await ky.get(server.url).json();
 	const responseText = await ky.get(server.url).text();
 
-	t.deepEqual(responseJson, 'not json');
-	t.deepEqual(responseText, 'not json');
+	t.is(responseJson, 'not json');
+	t.is(responseText, 'not json');
 
 	await server.close();
 });

--- a/test/main.ts
+++ b/test/main.ts
@@ -269,12 +269,11 @@ test('.json() with invalid JSON body', async t => {
 test('.json() with invalid JSON body and accept starts with text', async t => {
 	const server = await createHttpTestServer();
 	server.get('/', async (request, response) => {
-		t.is(request.headers.accept, 'text/plain');
 		response.end('not json');
 	});
 
 	// I think the code is a bit weird in this situation.
-	const responseJson = await ky.get(server.url).json();
+	const responseJson = await ky.get(server.url, {headers: {accept: 'text/plain'}}).json();
 	const responseText = await ky.get(server.url).text();
 
 	t.is(responseJson, 'not json');


### PR DESCRIPTION
Fixed #556 

## [Example]

```ts
const instance = ky.create({});

// URL returns string 'OK'
instance.get(URL).text();
```

## [Error Message]

```
VM21639:1 Uncaught (in promise) SyntaxError: Unexpected token 'O', "OK" is not valid JSON
```

Same as  when use`JSON.parse('OK')`

## [Temporary solution]

```ts
instance.get(URL, { parseJson: (text) => text }).text();
```

## [Description]

For `json` type, if there is no JSON type of response, an exception occurs when invoking the `JSON.parse` function.
The `text` method of `Response` has been modified to return a string as it is in the response.
I think we can discuss which values we should return (whether we return empty strings like 204)
I think it's an error to have a parsing error when the user didn't directly call the `json` method.

2024.01.17
It was modified from using the try catch block to confirm the `accpet` of the request header.
If the type is `json` and you can't parse it with JSON and you don't want to process it, I'd like your opinion.
