### PR TITLE
Fix `exactOptionalPropertyTypes`, fix TypeScript 5.4

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -118,9 +118,13 @@ export class Ky {
 	// eslint-disable-next-line complexity
 	constructor(input: Input, options: Options = {}) {
 		this._input = input;
-		const isCredentialsSupported = 'credentials' in Request.prototype;
+		const credentials
+			= this._input instanceof Request && 'credentials' in Request.prototype
+				? this._input.credentials
+				: undefined;
+
 		this._options = {
-			credentials: isCredentialsSupported ? (this._input as Request).credentials : undefined,
+			...(credentials && {credentials}), // For exactOptionalPropertyTypes
 			...options,
 			headers: mergeHeaders((this._input as Request).headers, options.headers),
 			hooks: deepMerge<Required<Hooks>>(

--- a/source/core/constants.ts
+++ b/source/core/constants.ts
@@ -76,4 +76,5 @@ export const requestOptionsRegistry: RequestInitRegistry = {
 	window: true,
 	dispatcher: true,
 	duplex: true,
+	priority: true,
 };

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -245,7 +245,6 @@ Omit<Options, 'hooks' | 'retry'>,
 	hooks: Required<Hooks>;
 	retry: Required<RetryOptions>;
 	prefixUrl: string;
-	credentials?: Options['credentials']; // Allows credentials to be undefined for workers
 };
 
 /**
@@ -254,7 +253,7 @@ Normalized options passed to the `fetch` call and the `beforeRequest` hooks.
 export interface NormalizedOptions extends RequestInit { // eslint-disable-line @typescript-eslint/consistent-type-definitions -- This must stay an interface so that it can be extended outside of Ky for use in `ky.create`.
 	// Extended from `RequestInit`, but ensured to be set (not optional).
 	method: NonNullable<RequestInit['method']>;
-	credentials: RequestInit['credentials'];
+	credentials?: NonNullable<RequestInit['credentials']>;
 
 	// Extended from custom `KyOptions`, but ensured to be set (not optional).
 	retry: RetryOptions;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"extends": "@sindresorhus/tsconfig",
+	"compilerOptions": {
+		"exactOptionalPropertyTypes": true
+	},
 	"include": [
 		"source"
 	]


### PR DESCRIPTION
https://github.com/sindresorhus/ky/pull/559 undid the fix in https://github.com/sindresorhus/ky/pull/543. Added `exactOptionalPropertyTypes` to `compilerOptions` to prevent this from happening again, seems pretty low-impact. It should be okay to pass `undefined` to `credentials` and other options, but this is an upstream problem (see `RequestInit` in `undici-types/fetch.d.ts`).

The build was failing on TS 5.4 because there's a `priority` in `RequestInit` now.