### PR TITLE
fix a small typo in a JSDoc comment

### DIFF
--- a/source/types/hooks.ts
+++ b/source/types/hooks.ts
@@ -25,7 +25,7 @@ export type BeforeErrorHook = (error: HTTPError) => HTTPError | Promise<HTTPErro
 
 export type Hooks = {
 	/**
-	This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives normalized input and options as arguments. You could, forf example, modiy `options.headers` here.
+	This hook enables you to modify the request right before it is sent. Ky will make no further changes to the request after this. The hook function receives normalized input and options as arguments. You could, for example, modify `options.headers` here.
 
 	A [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) can be returned from this hook to completely avoid making a HTTP request. This can be used to mock a request, check an internal cache, etc. An **important** consideration when returning a `Response` from this hook is that all the following hooks will be skipped, so **ensure you only return a `Response` from the last hook**.
 


### PR DESCRIPTION
I saw these typos while doing some debugging, so I figured I should go ahead and submit a fix!