### PR TITLE
Fix request types for use with Node

### DIFF
--- a/source/types/request.ts
+++ b/source/types/request.ts
@@ -1,15 +1,49 @@
+type UndiciHeadersInit =
+	| string[][]
+	| Record<string, string | readonly string[]>
+	| Headers;
+
+type UndiciBodyInit =
+	| ArrayBuffer
+	| AsyncIterable<Uint8Array>
+	| Blob
+	| FormData
+	| Iterable<Uint8Array>
+	| NodeJS.ArrayBufferView
+	| URLSearchParams
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	| null
+	| string;
+
+type UndiciRequestRedirect = 'error' | 'follow' | 'manual';
+
+type UndiciRequestCredentials = 'omit' | 'include' | 'same-origin';
+
+type UndiciReferrerPolicy =
+	| ''
+	| 'no-referrer'
+	| 'no-referrer-when-downgrade'
+	| 'origin'
+	| 'origin-when-cross-origin'
+	| 'same-origin'
+	| 'strict-origin'
+	| 'strict-origin-when-cross-origin'
+	| 'unsafe-url';
+
+type UndiciRequestMode = 'cors' | 'navigate' | 'no-cors' | 'same-origin';
+
 type UndiciRequestInit = {
 	method?: string;
 	keepalive?: boolean;
-	headers?: HeadersInit;
-	body?: BodyInit;
-	redirect?: RequestRedirect;
+	headers?: UndiciHeadersInit;
+	body?: UndiciBodyInit;
+	redirect?: UndiciRequestRedirect;
 	integrity?: string;
 	signal?: AbortSignal | undefined;
-	credentials?: RequestCredentials;
-	mode?: RequestMode;
+	credentials?: UndiciRequestCredentials;
+	mode?: UndiciRequestMode;
 	referrer?: string;
-	referrerPolicy?: ReferrerPolicy;
+	referrerPolicy?: UndiciReferrerPolicy;
 	window?: undefined;
 	dispatcher?: unknown;
 	duplex?: unknown;

--- a/source/types/request.ts
+++ b/source/types/request.ts
@@ -1,3 +1,9 @@
+/**
+ * Undici types need to be here because they are not exported to globals by @types/node.
+ * See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69408
+ *
+ * After the types are exported to globals, the Undici types can be removed from here.
+ */
 type UndiciHeadersInit =
 	| string[][]
 	| Record<string, string | readonly string[]>

--- a/source/types/request.ts
+++ b/source/types/request.ts
@@ -1,9 +1,10 @@
-/**
- * Undici types need to be here because they are not exported to globals by @types/node.
- * See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69408
- *
- * After the types are exported to globals, the Undici types can be removed from here.
- */
+/*
+Undici types need to be here because they are not exported to globals by @types/node.
+See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69408
+
+After the types are exported to globals, the Undici types can be removed from here.
+*/
+
 type UndiciHeadersInit =
 	| string[][]
 	| Record<string, string | readonly string[]>


### PR DESCRIPTION
<img width="609" alt="Screenshot 2024-04-20 at 21 59 11" src="https://github.com/sindresorhus/ky/assets/1022541/34c7e1ac-1d29-4439-8a33-4f46046487d5">

When using Ky with Node, TypeScript will run into compilation error regarding types required by `UndiciRequestInit`. This is because `@types/node` does not yet provide these types, and they are not imported from `undici-types` either. The latter would not even be possible to keep Ky usable with browsers.

This happened to work in the project, because `@sindresorhus/tsconfig` includes `DOM` in the libs section. In most Node applications, the DOM lib should not be there and clashes with Node types. One way to circumvent this is to add `skipLibCheck: true` to `tsconfig.json`, but this is not a good solution.

This commit adds the needed types until `@types/node` imports the missing types and adds them to globals. After that, all "Undici" types from the request types should be removed.