### PR TITLE
feat: add support for `stringifyJson`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -440,9 +440,9 @@ Use-cases:
 import ky from 'ky';
 import { DateTime } from 'luxon';
 const json = await ky('https://example.com', {
-	stringifyJson: data => JSON.stringify(data, (_, value) => {
-		if (value instanceof DateTime) {
-			return value.toSeconds();
+	stringifyJson: data => JSON.stringify(data, (key, value) => {
+		if (key.endsWith('_at')) {
+			return DateTime.fromISO(value).toSeconds();
 		}
 		return value;
 	})

--- a/readme.md
+++ b/readme.md
@@ -436,7 +436,7 @@ Default: `JSON.stringify()`
 User-defined JSON-stringifying function.
 
 Use-cases:
-1. Stringify JSON with the custom `replacer` function.
+1. Stringify JSON with a custom `replacer` function.
 
 ```js
 import ky from 'ky';

--- a/readme.md
+++ b/readme.md
@@ -438,12 +438,14 @@ Use-cases:
 
 ```js
 import ky from 'ky';
-import { DateTime } from 'luxon';
+import {DateTime} from 'luxon';
+
 const json = await ky('https://example.com', {
 	stringifyJson: data => JSON.stringify(data, (key, value) => {
 		if (key.endsWith('_at')) {
 			return DateTime.fromISO(value).toSeconds();
 		}
+
 		return value;
 	})
 }).json();

--- a/readme.md
+++ b/readme.md
@@ -426,6 +426,29 @@ const json = await ky('https://example.com', {
 }).json();
 ```
 
+##### stringifyJson
+
+Type: `Function`\
+Default: `JSON.stringify()`
+
+User-defined JSON-stringifying function.
+
+Use-cases:
+1. Stringify JSON with the custom `replacer` function.
+
+```js
+import ky from 'ky';
+import { DateTime } from 'luxon';
+const json = await ky('https://example.com', {
+	stringifyJson: data => JSON.stringify(data, (_, value) => {
+		if (value instanceof DateTime) {
+			return value.toSeconds();
+		}
+		return value;
+	})
+}).json();
+```
+
 ##### fetch
 
 Type: `Function`\

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -203,7 +203,7 @@ export class Ky {
 		}
 
 		if (this._options.json !== undefined) {
-			this._options.body = JSON.stringify(this._options.json);
+			this._options.body = this._options.stringifyJson ? this._options.stringifyJson(this._options.json) : JSON.stringify(this._options.json);
 			this.request.headers.set('content-type', this._options.headers.get('content-type') ?? 'application/json');
 			this.request = new globalThis.Request(this.request, {body: this._options.body});
 		}

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -203,7 +203,7 @@ export class Ky {
 		}
 
 		if (this._options.json !== undefined) {
-			this._options.body = this._options.stringifyJson ? this._options.stringifyJson(this._options.json) : JSON.stringify(this._options.json);
+			this._options.body = this._options.stringifyJson?.(this._options.json) ?? JSON.stringify(this._options.json);
 			this.request.headers.set('content-type', this._options.headers.get('content-type') ?? 'application/json');
 			this.request = new globalThis.Request(this.request, {body: this._options.body});
 		}

--- a/source/core/constants.ts
+++ b/source/core/constants.ts
@@ -50,6 +50,7 @@ export const stop = Symbol('stop');
 export const kyOptionKeys: KyOptionsRegistry = {
 	json: true,
 	parseJson: true,
+	stringifyJson: true,
 	searchParams: true,
 	prefixUrl: true,
 	retry: true,

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -62,7 +62,7 @@ export type KyOptions = {
 	User-defined JSON-stringifying function.
 
 	Use-cases:
-	1. Stringify JSON with the custom `replacer` function.
+	1. Stringify JSON with a custom `replacer` function.
 
 	@default JSON.stringify()
 

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -59,6 +59,32 @@ export type KyOptions = {
 	parseJson?: (text: string) => unknown;
 
 	/**
+	User-defined JSON-stringifying function.
+
+	Use-cases:
+	1. Stringify JSON with the custom `replacer` function.
+
+	@default JSON.stringify()
+
+	@example
+	```
+	import ky from 'ky';
+	import { DateTime } from 'luxon';
+
+	const json = await ky('https://example.com', {
+		stringifyJson: data => JSON.stringify(data, (_, value) => {
+			if (value instanceof DateTime) {
+				return value.toSeconds();
+			}
+
+			return value;
+		})
+	}).json();
+	```
+	 */
+	stringifyJson?: (data: unknown) => string;
+
+	/**
 	Search parameters to include in the request URL. Setting this will override all existing search parameters in the input URL.
 
 	Accepts any value supported by [`URLSearchParams()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams).

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -72,9 +72,9 @@ export type KyOptions = {
 	import { DateTime } from 'luxon';
 
 	const json = await ky('https://example.com', {
-		stringifyJson: data => JSON.stringify(data, (_, value) => {
-			if (value instanceof DateTime) {
-				return value.toSeconds();
+		stringifyJson: data => JSON.stringify(data, (key, value) => {
+			if (key.endsWith('_at')) {
+				return DateTime.fromISO(value).toSeconds();
 			}
 
 			return value;

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -69,7 +69,7 @@ export type KyOptions = {
 	@example
 	```
 	import ky from 'ky';
-	import { DateTime } from 'luxon';
+	import {DateTime} from 'luxon';
 
 	const json = await ky('https://example.com', {
 		stringifyJson: data => JSON.stringify(data, (key, value) => {
@@ -81,7 +81,7 @@ export type KyOptions = {
 		})
 	}).json();
 	```
-	 */
+	*/
 	stringifyJson?: (data: unknown) => string;
 
 	/**

--- a/test/main.ts
+++ b/test/main.ts
@@ -736,13 +736,15 @@ test('parseJson option with promise.json() shortcut', async t => {
 
 test('stringifyJson option with request.json()', async t => {
 	const server = await createHttpTestServer({bodyParser: false});
+	
+	const json = {hello: 'world'};
+	const result = {data: json, extra: 'extraValue'};
+
 	server.post('/', async (request, response) => {
 		const body = await parseRawBody(request);
-		t.is(body, '{"data":{"hello":"world"},"extra":"extraValue"}');
+		t.is(body, JSON.stringify(result));
 		response.end();
 	});
-
-	const json = {hello: 'world'};
 
 	await ky.post(server.url, {
 		stringifyJson: data => JSON.stringify({

--- a/test/main.ts
+++ b/test/main.ts
@@ -736,7 +736,7 @@ test('parseJson option with promise.json() shortcut', async t => {
 
 test('stringifyJson option with request.json()', async t => {
 	const server = await createHttpTestServer({bodyParser: false});
-	
+
 	const json = {hello: 'world'};
 	const result = {data: json, extra: 'extraValue'};
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -733,3 +733,24 @@ test('parseJson option with promise.json() shortcut', async t => {
 
 	await server.close();
 });
+
+test('stringifyJson option with request.json()', async t => {
+	const server = await createHttpTestServer({bodyParser: false});
+	server.post('/', async (request, response) => {
+		const body = await parseRawBody(request);
+		t.is(body, '{"data":{"hello":"world"},"extra":"extraValue"}');
+		response.end();
+	});
+
+	const json = {hello: 'world'};
+
+	await ky.post(server.url, {
+		stringifyJson: data => JSON.stringify({
+			data,
+			extra: 'extraValue',
+		}),
+		json,
+	});
+
+	await server.close();
+});

--- a/test/main.ts
+++ b/test/main.ts
@@ -738,19 +738,16 @@ test('stringifyJson option with request.json()', async t => {
 	const server = await createHttpTestServer({bodyParser: false});
 
 	const json = {hello: 'world'};
-	const result = {data: json, extra: 'extraValue'};
+	const extra = 'extraValue';
 
 	server.post('/', async (request, response) => {
 		const body = await parseRawBody(request);
-		t.is(body, JSON.stringify(result));
+		t.is(body, JSON.stringify({data: json, extra}));
 		response.end();
 	});
 
 	await ky.post(server.url, {
-		stringifyJson: data => JSON.stringify({
-			data,
-			extra: 'extraValue',
-		}),
+		stringifyJson: data => JSON.stringify({data, extra}),
 		json,
 	});
 


### PR DESCRIPTION
When sending an HTTP request, this option allows the user to specify how the request data should be serialized as a string.

For example, it will be useful when users want to change the default serialization behavior using `JSON.stringify(_, replacer)`.

```typescript
import ky from 'ky';
import { DateTime } from 'luxon';

const json = await ky('https://example.com', {
  stringifyJson: data => JSON.stringify(data, (key, value) => {
    if (key.endsWith('_at')) {
      return DateTime.fromISO(value).toSeconds();
    }
    return value;
  })
}).json();
```

