### PR TITLE
Add request method and URL to error messages

### DIFF
--- a/source/errors/HTTPError.ts
+++ b/source/errors/HTTPError.ts
@@ -12,7 +12,7 @@ export class HTTPError extends Error {
 		const status = `${code} ${title}`.trim();
 		const reason = status ? `status code ${status}` : 'an unknown error';
 
-		super(`Request failed with ${reason}`);
+		super(`Request failed with ${reason}: ${request.method} ${request.url}`);
 
 		this.name = 'HTTPError';
 		this.response = response;

--- a/source/errors/TimeoutError.ts
+++ b/source/errors/TimeoutError.ts
@@ -2,7 +2,7 @@ export class TimeoutError extends Error {
 	public request: Request;
 
 	constructor(request: Request) {
-		super('Request timed out');
+		super(`Request timed out: ${request.method} ${request.url}`);
 		this.name = 'TimeoutError';
 		this.request = request;
 	}

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -244,7 +244,7 @@ defaultBrowsersTest(
 			throw new TypeError('Expected to have an object error');
 		}
 
-		t.is(error.message, 'TimeoutError: Request timed out');
+		t.is(error.message, `TimeoutError: Request timed out: GET ${server.url}/slow`);
 		t.is(error.request.url, `${server.url}/slow`);
 	},
 );
@@ -480,7 +480,7 @@ browserTest('retry with body', [chromium, webkit], async (t: ExecutionContext, p
 			method: 'PUT',
 			retry: 1,
 		}), server.url),
-		{message: /HTTPError: Request failed with status code 502 Bad Gateway/},
+		{message: /HTTPError: Request failed with status code 502 Bad Gateway: PUT/},
 	);
 
 	t.is(requestCount, 2);

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -482,7 +482,7 @@ test('beforeRetry hook with parseJson and error.response.json()', async t => {
 				beforeRetry: [
 					async ({error, retryCount}) => {
 						t.true(error instanceof HTTPError);
-						t.is(error.message, 'Request failed with status code 502 Bad Gateway');
+						t.is(error.message, `Request failed with status code 502 Bad Gateway: GET ${server.url}/`);
 						t.true((error as HTTPError).response instanceof Response);
 						t.deepEqual(await (error as HTTPError).response.json(), {awesome: true});
 						t.is(retryCount, 1);

--- a/test/http-error.ts
+++ b/test/http-error.ts
@@ -20,9 +20,10 @@ test('HTTPError handles undefined response.statusText', t => {
 		// not define statusText, such as IE, Safari, etc.
 		// See https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText#Browser_compatibility
 		createFakeResponse({statusText: undefined, status}),
+		new Request('invalid:foo'),
 	);
 
-	t.is(error.message, 'Request failed with status code 500');
+	t.is(error.message, 'Request failed with status code 500: GET invalid:foo');
 });
 
 test('HTTPError handles undefined response.status', t => {
@@ -31,9 +32,10 @@ test('HTTPError handles undefined response.status', t => {
 		// This simulates a catastrophic case where some unexpected
 		// response object was sent to HTTPError.
 		createFakeResponse({statusText: undefined, status: undefined}),
+		new Request('invalid:foo'),
 	);
 
-	t.is(error.message, 'Request failed with an unknown error');
+	t.is(error.message, 'Request failed with an unknown error: GET invalid:foo');
 });
 
 test('HTTPError handles a response.status of 0', t => {
@@ -41,7 +43,8 @@ test('HTTPError handles a response.status of 0', t => {
 	const error = new HTTPError(
 		// Apparently, it's possible to get a response status of 0.
 		createFakeResponse({statusText: undefined, status: 0}),
+		new Request('invalid:foo'),
 	);
 
-	t.is(error.message, 'Request failed with status code 0');
+	t.is(error.message, 'Request failed with status code 0: GET invalid:foo');
 });


### PR DESCRIPTION
Closes #592

This PR aims to make the error messages from Ky's `TimeoutError` and `HTTPError` more helpful by including the request method and URL.

Before:

```
TimeoutError: Request timed out
```
```
HTTPError: Request failed with status code 400 Bad Request
```

After:

```
TimeoutError: Request timed out: POST https://localhost:3000/
```
```
HTTPError: Request failed with status code 400 Bad Request: POST https://localhost:3000/
```