### PR TITLE
Clamp Retry-After time to retry.maxRetryAfter

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -219,18 +219,13 @@ export class Ky {
 
 				const retryAfter = error.response.headers.get('Retry-After');
 				if (retryAfter && this._options.retry.afterStatusCodes.includes(error.response.status)) {
-					let after = Number(retryAfter);
+					let after = Number(retryAfter) * 1000;
 					if (Number.isNaN(after)) {
 						after = Date.parse(retryAfter) - Date.now();
-					} else {
-						after *= 1000;
 					}
 
-					if (this._options.retry.maxRetryAfter !== undefined && after > this._options.retry.maxRetryAfter) {
-						return 0;
-					}
-
-					return after;
+					const max = this._options.retry.maxRetryAfter ?? after;
+					return after < max ? after : max;
 				}
 
 				if (error.response.status === 413) {


### PR DESCRIPTION
Relates to #390 

This PR aims to make retry delays more intuitive.

Previously, we would respect the `Retry-After` header to determine the delay time for the retry, but if `Retry-After` was greater than the `retry.maxRetryAfter` option, then the retry delay time would be set to `0`, effectively canceling it, given Ky's current logic.

We now use `maxRetryAfter` as a limit for the delay, rather than a threshold for canceling the retry. If `Retry-After` is greater than `maxRetryAfter`, then `maxRetryAfter` will be used as the delay time.