### PR TITLE
Fix signal handling for Request objects

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -129,8 +129,11 @@ export class Ky {
 				? this._input.credentials
 				: undefined;
 
+		const signal = this._input instanceof Request ? this._input.signal : undefined;
+
 		this._options = {
 			...(credentials && {credentials}), // For exactOptionalPropertyTypes
+			...(signal && {signal}), // For exactOptionalPropertyTypes
 			...options,
 			headers: mergeHeaders((this._input as Request).headers, options.headers),
 			hooks: deepMerge<Required<Hooks>>(

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -169,7 +169,7 @@ export class Ky {
 
 		if (supportsAbortController) {
 			this.abortController = new globalThis.AbortController();
-			const originalSignal = this._options.signal || (this._input as Request).signal;
+			const originalSignal = this._options.signal ?? (this._input as Request).signal;
 			if (originalSignal) {
 				originalSignal.addEventListener('abort', () => {
 					this.abortController!.abort(originalSignal.reason);

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -170,11 +170,9 @@ export class Ky {
 		if (supportsAbortController) {
 			this.abortController = new globalThis.AbortController();
 			const originalSignal = this._options.signal ?? (this._input as Request).signal;
-			if (originalSignal) {
-				originalSignal.addEventListener('abort', () => {
-					this.abortController!.abort(originalSignal.reason);
-				});
-			}
+			originalSignal?.addEventListener('abort', () => {
+				this.abortController!.abort(originalSignal.reason);
+			});
 
 			this._options.signal = this.abortController.signal;
 		}

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -129,11 +129,8 @@ export class Ky {
 				? this._input.credentials
 				: undefined;
 
-		const signal = this._input instanceof Request ? this._input.signal : undefined;
-
 		this._options = {
 			...(credentials && {credentials}), // For exactOptionalPropertyTypes
-			...(signal && {signal}), // For exactOptionalPropertyTypes
 			...options,
 			headers: mergeHeaders((this._input as Request).headers, options.headers),
 			hooks: deepMerge<Required<Hooks>>(
@@ -172,10 +169,9 @@ export class Ky {
 
 		if (supportsAbortController) {
 			this.abortController = new globalThis.AbortController();
-			if (this._options.signal) {
-				const originalSignal = this._options.signal;
-
-				this._options.signal.addEventListener('abort', () => {
+			const originalSignal = this._options.signal || (this._input as Request).signal;
+			if (originalSignal) {
+				originalSignal.addEventListener('abort', () => {
 					this.abortController!.abort(originalSignal.reason);
 				});
 			}

--- a/test/main.ts
+++ b/test/main.ts
@@ -655,6 +655,23 @@ test('throws DOMException/Error with name AbortError when aborted by user', asyn
 	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
 });
 
+test('throws AbortError when aborted via Request', async t => {
+	const server = await createHttpTestServer();
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	server.get('/', () => {});
+
+	const abortController = new AbortController();
+	const {signal} = abortController;
+	const request = new Request(server.url, {signal});
+	const response = ky(request);
+	abortController.abort();
+
+	const error = (await t.throwsAsync(response))!;
+
+	t.true(['DOMException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
+	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
+});
+
 test('supports Request instance as input', async t => {
 	const server = await createHttpTestServer();
 	const inputRequest = new Request(server.url, {method: 'POST'});


### PR DESCRIPTION
Currently, ky ignores `AbortSignal` when it's provided as part of a `Request` object.

This PR modifies the `Ky` class to properly extract and respect the `AbortSignal` from `Request` objects. It ensures that signals are handled consistently whether they're provided directly in the options or as part of a `Request` object.