### PR TITLE
Remove unnecessary setting of `credentials` option

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -123,13 +123,8 @@ export class Ky {
 	// eslint-disable-next-line complexity
 	constructor(input: Input, options: Options = {}) {
 		this._input = input;
-		const credentials
-			= this._input instanceof Request && 'credentials' in Request.prototype
-				? this._input.credentials
-				: undefined;
 
 		this._options = {
-			...(credentials && {credentials}), // For exactOptionalPropertyTypes
 			...options,
 			headers: mergeHeaders((this._input as Request).headers, options.headers),
 			hooks: mergeHooks(


### PR DESCRIPTION
This PR is just internal housekeeping. No user-visible changes are intended.

The `input.credentials` will be used automatically by `fetch()` if `options.credentials` is not defined, so copying it over manually is unnecessary.