### PR TITLE
Add support for the `RateLimit-Reset` header

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -208,7 +208,7 @@ An object representing `limit`, `methods`, `statusCodes`, `afterStatusCodes`, an
 
 If `retry` is a number, it will be used as `limit` and other defaults will remain in place.
 
-If the response provides an HTTP status contained in `afterStatusCodes`, Ky will wait until the date or timeout given in the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header has passed to retry the request. If `Retry-After` is missing, the non-standard [`RateLimit-Reset`](https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-02.html#section-3.3) header is used in its place as a fallback. If the provided status code is not in the list, the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header will be ignored.
+If the response provides an HTTP status contained in `afterStatusCodes`, Ky will wait until the date, timeout, or timestamp given in the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header has passed to retry the request. If `Retry-After` is missing, the non-standard [`RateLimit-Reset`](https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-05.html#section-3.3) header is used in its place as a fallback. If the provided status code is not in the list, the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header will be ignored.
 
 If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is greater than `maxRetryAfter`, it will use `maxRetryAfter`.
 

--- a/readme.md
+++ b/readme.md
@@ -208,7 +208,7 @@ An object representing `limit`, `methods`, `statusCodes`, `afterStatusCodes`, an
 
 If `retry` is a number, it will be used as `limit` and other defaults will remain in place.
 
-If the response provides an HTTP status contained in `afterStatusCodes`, Ky will wait until the date or timeout given in the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header has passed to retry the request. If the provided status code is not in the list, the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header will be ignored.
+If the response provides an HTTP status contained in `afterStatusCodes`, Ky will wait until the date or timeout given in the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header has passed to retry the request. If `Retry-After` is missing, the non-standard [`RateLimit-Reset`](https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-02.html#section-3.3) header is used in its place as a fallback. If the provided status code is not in the list, the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header will be ignored.
 
 If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is greater than `maxRetryAfter`, it will use `maxRetryAfter`.
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -219,11 +219,15 @@ export class Ky {
 
 			const retryAfter = error.response.headers.get('Retry-After')
 				?? error.response.headers.get('RateLimit-Reset')
-				?? error.response.headers.get('X-RateLimit-Reset');
+				?? error.response.headers.get('X-RateLimit-Reset') // GitHub
+				?? error.response.headers.get('X-Rate-Limit-Reset'); // Twitter
 			if (retryAfter && this._options.retry.afterStatusCodes.includes(error.response.status)) {
 				let after = Number(retryAfter) * 1000;
 				if (Number.isNaN(after)) {
 					after = Date.parse(retryAfter) - Date.now();
+				} else if (after >= Date.parse('2024-01-01')) {
+					// Large numbers are treated as time since the UNIX epoch (fixed threshold protects against clock skew)
+					after -= Date.now();
 				}
 
 				const max = this._options.retry.maxRetryAfter ?? after;

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -226,7 +226,7 @@ export class Ky {
 				if (Number.isNaN(after)) {
 					after = Date.parse(retryAfter) - Date.now();
 				} else if (after >= Date.parse('2024-01-01')) {
-					// Large numbers are treated as time since the UNIX epoch (fixed threshold protects against clock skew)
+					// A large number is treated as a timestamp (fixed threshold protects against clock skew)
 					after -= Date.now();
 				}
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -217,7 +217,9 @@ export class Ky {
 				throw error;
 			}
 
-			const retryAfter = error.response.headers.get('Retry-After');
+			const retryAfter = error.response.headers.get('Retry-After')
+				?? error.response.headers.get('RateLimit-Reset')
+				?? error.response.headers.get('X-RateLimit-Reset');
 			if (retryAfter && this._options.retry.afterStatusCodes.includes(error.response.status)) {
 				let after = Number(retryAfter) * 1000;
 				if (Number.isNaN(after)) {

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -120,7 +120,7 @@ export type KyOptions = {
 
 	If `retry` is a number, it will be used as `limit` and other defaults will remain in place.
 
-	If the response provides an HTTP status contained in `afterStatusCodes`, Ky will wait until the date or timeout given in the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header has passed to retry the request. If the provided status code is not in the list, the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header will be ignored.
+	If the response provides an HTTP status contained in `afterStatusCodes`, Ky will wait until the date or timeout given in the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header has passed to retry the request. If `Retry-After` is missing, the non-standard [`RateLimit-Reset`](https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-02.html#section-3.3) header is used in its place as a fallback. If the provided status code is not in the list, the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header will be ignored.
 
 	If `maxRetryAfter` is set to `undefined`, it will use `options.timeout`. If [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is greater than `maxRetryAfter`, it will cancel the request.
 

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -156,6 +156,39 @@ test('RateLimit-Reset is treated the same as Retry-After', async t => {
 	await server.close();
 });
 
+test('RateLimit-Reset with time since epoch', async t => {
+	let requestCount = 0;
+
+	const server = await createHttpTestServer();
+	server.get('/', (_request, response) => {
+		requestCount++;
+
+		if (requestCount === defaultRetryCount + 1) {
+			response.end(fixture);
+		} else {
+			const twoSecondsByDelta = 2;
+			const oneSecondByEpoch = (Date.now() / 1000) + 1;
+			response.writeHead(429, {
+				'RateLimit-Reset': (requestCount < 2) ? twoSecondsByDelta : oneSecondByEpoch,
+			});
+
+			response.end('');
+		}
+	});
+
+	await withPerformance({
+		t,
+		expectedDuration: 2000 + 1000,
+		async test() {
+			t.is(await ky(server.url).text(), fixture);
+		},
+	});
+
+	t.is(requestCount, 3);
+
+	await server.close();
+});
+
 test('respect 413 Retry-After', async t => {
 	const startTime = Date.now();
 	let requestCount = 0;

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -124,6 +124,38 @@ test('respect Retry-After: 0 and retry immediately', async t => {
 	await server.close();
 });
 
+test('RateLimit-Reset is treated the same as Retry-After', async t => {
+	let requestCount = 0;
+
+	const server = await createHttpTestServer();
+	server.get('/', (_request, response) => {
+		requestCount++;
+
+		if (requestCount === defaultRetryCount + 1) {
+			response.end(fixture);
+		} else {
+			const header = (requestCount < 2) ? 'RateLimit-Reset' : 'Retry-After';
+			response.writeHead(429, {
+				[header]: 1,
+			});
+
+			response.end('');
+		}
+	});
+
+	await withPerformance({
+		t,
+		expectedDuration: 1000 + 1000,
+		async test() {
+			t.is(await ky(server.url).text(), fixture);
+		},
+	});
+
+	t.is(requestCount, 3);
+
+	await server.close();
+});
+
 test('respect 413 Retry-After', async t => {
 	const startTime = Date.now();
 	let requestCount = 0;


### PR DESCRIPTION
Closes #608

This PR adds automatic handling for non-standard rate limiting headers that are used by some APIs (e.g. GitHub and Twitter) instead of `Retry-After`.

The following headers are now supported as a fallback for `Retry-After`:
 - `RateLimit-Reset` as proposed by https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-05.html#section-3.3
 - `X-RateLimit-Reset` as implemented by GitHub
 - `X-Rate-Limit-Reset` as implemented by Twitter

Dates, timeouts (delta seconds), and timestamps (seconds since epoch) are all supported.

Timestamps in milliseconds are not currently supported, as none of the popular APIs use it.

More variants are discussed here: https://github.com/ietf-wg-httpapi/ratelimit-headers/issues/25