### PR TITLE
Remove `NodeJS` type prefixing

### DIFF
--- a/source/types/request.ts
+++ b/source/types/request.ts
@@ -16,7 +16,7 @@ type UndiciBodyInit =
 	| Blob
 	| FormData
 	| Iterable<Uint8Array>
-	| NodeJS.ArrayBufferView
+	| ArrayBufferView
 	| URLSearchParams
 	// eslint-disable-next-line @typescript-eslint/ban-types
 	| null


### PR DESCRIPTION
`NodeJS.ArrayBufferView` type annotation fails when compiling for browsers. For details see #622 

closes #622 