### PR TITLE
Add support for string union types in searchParams Record value

### DIFF
--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -6,7 +6,7 @@ import type {RetryOptions} from './retry.js';
 export type SearchParamsInit = string | string[][] | Record<string, string> | URLSearchParams | undefined;
 
 // eslint-disable-next-line unicorn/prevent-abbreviations
-export type SearchParamsOption = SearchParamsInit | Record<string, string | number | boolean> | Array<Array<string | number | boolean>>;
+export type SearchParamsOption = SearchParamsInit | Record<string, string | number | boolean | unknown> | Array<Array<string | number | boolean>>;
 
 export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
 


### PR DESCRIPTION
## Problem Description

I am using `swagger-typescript-api` to automatically generate API functions, which are customized using an ejs template. The generated API request functions look like this:

```ts
import ky from 'ky';

type UserTypeEnum = 'user' | 'admin';

export const getUserList = (params?: { userType?: UserTypeEnum | null }) => {
  ky.get('https://example.com/user', {
    searchParams: params,
  });
};
```

However, the `Record` type used in `searchParams` does not support `string` union types as values, leading to the following TypeScript error:

```
TS2322: Type
{   userType?: UserTypeEnum | null | undefined; } | undefined
is not assignable to type SearchParamsOption
Type
{   userType?: UserTypeEnum | null | undefined; }
is not assignable to type SearchParamsOption
Type
{   userType?: UserTypeEnum | null | undefined; }
is not assignable to type Record<string, string | number | boolean>
Property userType is incompatible with index signature.
Type UserTypeEnum | null is not assignable to type string | number | boolean
Type null is not assignable to type string | number | boolean
```
![TypeScript Error Screenshot](https://github.com/user-attachments/assets/b391500b-7786-4a30-b0db-39bbacab43a4)

As a result, I am forced to cast `params` using `as never` to bypass the error, which is not ideal.

## Proposed Solution

By adding `unknown` to the value type of the `Record` used in `searchParams`, this TypeScript error can be resolved. This allows for better flexibility when dealing with union types, improving the overall developer experience.
