### PR TITLE
Revise CDN links in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,14 +65,9 @@ It's just a tiny package with no dependencies.
 npm install ky
 ```
 
-###### Download
-
-- [Normal](https://cdn.jsdelivr.net/npm/ky/index.js)
-- [Minified](https://cdn.jsdelivr.net/npm/ky/index.min.js)
-
 ###### CDN
 
-- [jsdelivr](https://www.jsdelivr.com/package/npm/ky)
+- [jsdelivr](https://cdn.jsdelivr.net/npm/ky/+esm)
 - [unpkg](https://unpkg.com/ky)
 - [esm.sh](https://esm.sh/ky)
 


### PR DESCRIPTION
I was a little baffled by the two "Download" links as I made #612. Turns out they are pointing to an older version of ky (0.16.2 according to the header of https://cdn.jsdelivr.net/npm/ky/index.min.js). This pull request removes them since they are long outdated.

Also changed the jsdelivr link below to a direct link usable in `<script src="...">`, in line with the unpkg and esm.sh link below.