### PR TITLE
Mark `ky.create()` options as optional in public types

### DIFF
--- a/source/types/ky.ts
+++ b/source/types/ky.ts
@@ -74,7 +74,7 @@ export type KyInstance = {
 
 	@returns A new Ky instance.
 	*/
-	create: (defaultOptions: Options) => KyInstance;
+	create: (defaultOptions?: Options) => KyInstance;
 
 	/**
 	Create a new Ky instance with some defaults overridden with your own.


### PR DESCRIPTION
Just a small tweak on the `ky.create()`. I know it's also possible to use the global `ky` instance, but just in case one wants to use this factory method instead.