### PR TITLE
Update readme.md to clarify HTTPError

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -608,6 +608,8 @@ const text = await ky('https://example.com', options).text();
 
 Exposed for `instanceof` checks. The error has a `response` property with the [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response), `request` property with the [`Request` object](https://developer.mozilla.org/en-US/docs/Web/API/Request), and `options` property with normalized options (either passed to `ky` when creating an instance with `ky.create()` or directly when performing the request).
 
+Be aware that some types of errors, such as network errors, inherently mean that a response was not received. In that case, the error will not be an instance of HTTPError and will not contain a `response` property.
+
 If you need to read the actual response when an `HTTPError` has occurred, call the respective parser method on the response object. For example:
 
 ```js


### PR DESCRIPTION
Clarifies that some errors (especially network errors) will not be an instance of HTTPError and not contain a response. Language copied from `hooks.beforeRetry`.

I believe it is important to reiterate this at the HTTPError level, as it is not immediately intuitive that all errors wouldn't be an instance of HTTPError.

Whether all errors *should* be an instance of HTTPError is up to debate (and I gather is actively under consideration in a number of issues/discussions), and is outside the scope of this PR.