### PR TITLE
Removed The Need For .js Extension For Imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,17 @@
 			"@typescript-eslint/no-unsafe-return": "off",
 			"@typescript-eslint/no-unsafe-call": "off",
 			"@typescript-eslint/naming-convention": "off",
-			"n/no-unsupported-features/node-builtins": "off"
+			"n/no-unsupported-features/node-builtins": "off",
+			"import/extensions": [
+				"error",
+				"ignorePackages",
+				{
+				  "js": "never",
+				  "jsx": "never",
+				  "ts": "never",
+				  "tsx": "never"
+				}
+			 ]
 		}
 	},
 	"ava": {

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -1,19 +1,19 @@
-import {HTTPError} from '../errors/HTTPError.js';
-import {TimeoutError} from '../errors/TimeoutError.js';
+import {HTTPError} from '../errors/HTTPError';
+import {TimeoutError} from '../errors/TimeoutError';
 import type {
 	Input,
 	InternalOptions,
 	NormalizedOptions,
 	Options,
 	SearchParamsInit,
-} from '../types/options.js';
-import {type ResponsePromise} from '../types/ResponsePromise.js';
-import {mergeHeaders, mergeHooks} from '../utils/merge.js';
-import {normalizeRequestMethod, normalizeRetryOptions} from '../utils/normalize.js';
-import timeout, {type TimeoutOptions} from '../utils/timeout.js';
-import delay from '../utils/delay.js';
-import {type ObjectEntries} from '../utils/types.js';
-import {findUnknownOptions} from '../utils/options.js';
+} from '../types/options';
+import {type ResponsePromise} from '../types/ResponsePromise';
+import {mergeHeaders, mergeHooks} from '../utils/merge';
+import {normalizeRequestMethod, normalizeRetryOptions} from '../utils/normalize';
+import timeout, {type TimeoutOptions} from '../utils/timeout';
+import delay from '../utils/delay';
+import {type ObjectEntries} from '../utils/types';
+import {findUnknownOptions} from '../utils/options';
 import {
 	maxSafeTimeout,
 	responseTypes,
@@ -22,7 +22,7 @@ import {
 	supportsFormData,
 	supportsResponseStreams,
 	supportsRequestStreams,
-} from './constants.js';
+} from './constants';
 
 export class Ky {
 	static create(input: Input, options: Options): ResponsePromise {

--- a/source/core/constants.ts
+++ b/source/core/constants.ts
@@ -1,6 +1,6 @@
 import type {Expect, Equal} from '@type-challenges/utils';
-import {type HttpMethod, type KyOptionsRegistry} from '../types/options.js';
-import {type RequestInitRegistry} from '../types/request.js';
+import {type HttpMethod, type KyOptionsRegistry} from '../types/options';
+import {type RequestInitRegistry} from '../types/request';
 
 export const supportsRequestStreams = (() => {
 	let duplexAccessed = false;

--- a/source/errors/HTTPError.ts
+++ b/source/errors/HTTPError.ts
@@ -1,6 +1,6 @@
-import type {NormalizedOptions} from '../types/options.js';
-import type {KyRequest} from '../types/request.js';
-import type {KyResponse} from '../types/response.js';
+import type {NormalizedOptions} from '../types/options';
+import type {KyRequest} from '../types/request';
+import type {KyResponse} from '../types/response';
 
 export class HTTPError<T = unknown> extends Error {
 	public response: KyResponse<T>;

--- a/source/errors/TimeoutError.ts
+++ b/source/errors/TimeoutError.ts
@@ -1,4 +1,4 @@
-import type {KyRequest} from '../types/request.js';
+import type {KyRequest} from '../types/request';
 
 export class TimeoutError extends Error {
 	public request: KyRequest;

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,11 +1,11 @@
 /*! MIT License © Sindre Sorhus */
 
-import {Ky} from './core/Ky.js';
-import {requestMethods, stop} from './core/constants.js';
-import type {KyInstance} from './types/ky.js';
-import type {Input, Options} from './types/options.js';
-import {validateAndMerge} from './utils/merge.js';
-import {type Mutable} from './utils/types.js';
+import {Ky} from './core/Ky';
+import {requestMethods, stop} from './core/constants';
+import type {KyInstance} from './types/ky';
+import type {Input, Options} from './types/options';
+import {validateAndMerge} from './utils/merge';
+import {type Mutable} from './utils/types';
 
 const createInstance = (defaults?: Partial<Options>): KyInstance => {
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -34,7 +34,7 @@ const ky = createInstance();
 
 export default ky;
 
-export type {KyInstance} from './types/ky.js';
+export type {KyInstance} from './types/ky';
 
 export type {
 	Input,
@@ -43,7 +43,7 @@ export type {
 	RetryOptions,
 	SearchParamsOption,
 	DownloadProgress,
-} from './types/options.js';
+} from './types/options';
 
 export type {
 	Hooks,
@@ -52,10 +52,10 @@ export type {
 	BeforeRetryState,
 	BeforeErrorHook,
 	AfterResponseHook,
-} from './types/hooks.js';
+} from './types/hooks';
 
-export type {ResponsePromise} from './types/ResponsePromise.js';
-export type {KyRequest} from './types/request.js';
-export type {KyResponse} from './types/response.js';
-export {HTTPError} from './errors/HTTPError.js';
-export {TimeoutError} from './errors/TimeoutError.js';
+export type {ResponsePromise} from './types/ResponsePromise';
+export type {KyRequest} from './types/request';
+export type {KyResponse} from './types/response';
+export {HTTPError} from './errors/HTTPError';
+export {TimeoutError} from './errors/TimeoutError';

--- a/source/types/ResponsePromise.ts
+++ b/source/types/ResponsePromise.ts
@@ -1,7 +1,7 @@
 /**
 Returns a `Response` object with `Body` methods added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return an empty string if body is empty or the response status is `204` instead of throwing a parse error due to an empty body.
 */
-import {type KyResponse} from './response.js';
+import {type KyResponse} from './response';
 
 export type ResponsePromise<T = unknown> = {
 	arrayBuffer: () => Promise<ArrayBuffer>;

--- a/source/types/hooks.ts
+++ b/source/types/hooks.ts
@@ -1,6 +1,6 @@
-import {type stop} from '../core/constants.js';
-import type {KyRequest, KyResponse, HTTPError} from '../index.js';
-import type {NormalizedOptions} from './options.js';
+import {type stop} from '../core/constants';
+import type {KyRequest, KyResponse, HTTPError} from '../index';
+import type {NormalizedOptions} from './options';
 
 export type BeforeRequestHook = (
 	request: KyRequest,

--- a/source/types/ky.ts
+++ b/source/types/ky.ts
@@ -1,6 +1,6 @@
-import {type stop} from '../core/constants.js';
-import type {Input, Options} from './options.js';
-import type {ResponsePromise} from './ResponsePromise.js';
+import {type stop} from '../core/constants';
+import type {Input, Options} from './options';
+import type {ResponsePromise} from './ResponsePromise';
 
 export type KyInstance = {
 	/**

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -1,6 +1,6 @@
-import type {LiteralUnion, Required} from './common.js';
-import type {Hooks} from './hooks.js';
-import type {RetryOptions} from './retry.js';
+import type {LiteralUnion, Required} from './common';
+import type {Hooks} from './hooks';
+import type {RetryOptions} from './retry';
 
 // eslint-disable-next-line unicorn/prevent-abbreviations
 export type SearchParamsInit = string | string[][] | Record<string, string> | URLSearchParams | undefined;
@@ -289,4 +289,4 @@ export interface NormalizedOptions extends RequestInit { // eslint-disable-line 
 	onDownloadProgress: Options['onDownloadProgress'];
 }
 
-export type {RetryOptions} from './retry.js';
+export type {RetryOptions} from './retry';

--- a/source/utils/delay.ts
+++ b/source/utils/delay.ts
@@ -1,6 +1,6 @@
 // https://github.com/sindresorhus/delay/tree/ab98ae8dfcb38e1593286c94d934e70d14a4e111
 
-import {type InternalOptions} from '../types/options.js';
+import {type InternalOptions} from '../types/options';
 
 export type DelayOptions = {
 	signal?: InternalOptions['signal'];

--- a/source/utils/merge.ts
+++ b/source/utils/merge.ts
@@ -1,6 +1,6 @@
-import type {KyHeadersInit, Options} from '../types/options.js';
-import type {Hooks} from '../types/hooks.js';
-import {isObject} from './is.js';
+import type {KyHeadersInit, Options} from '../types/options';
+import type {Hooks} from '../types/hooks';
+import {isObject} from './is';
 
 export const validateAndMerge = (...sources: Array<Partial<Options> | undefined>): Partial<Options> => {
 	for (const source of sources) {

--- a/source/utils/normalize.ts
+++ b/source/utils/normalize.ts
@@ -1,6 +1,6 @@
-import {requestMethods} from '../core/constants.js';
-import type {HttpMethod} from '../types/options.js';
-import type {RetryOptions} from '../types/retry.js';
+import {requestMethods} from '../core/constants';
+import type {HttpMethod} from '../types/options';
+import type {RetryOptions} from '../types/retry';
 
 export const normalizeRequestMethod = (input: string): string =>
 	requestMethods.includes(input as HttpMethod) ? input.toUpperCase() : input;

--- a/source/utils/options.ts
+++ b/source/utils/options.ts
@@ -1,4 +1,4 @@
-import {kyOptionKeys, requestOptionsRegistry} from '../core/constants.js';
+import {kyOptionKeys, requestOptionsRegistry} from '../core/constants';
 
 export const findUnknownOptions = (
 	request: Request,

--- a/source/utils/timeout.ts
+++ b/source/utils/timeout.ts
@@ -1,4 +1,4 @@
-import {TimeoutError} from '../errors/TimeoutError.js';
+import {TimeoutError} from '../errors/TimeoutError';
 
 export type TimeoutOptions = {
 	timeout: number;

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -2,11 +2,11 @@ import test, {type ExecutionContext} from 'ava';
 import busboy from 'busboy';
 import express from 'express';
 import {chromium, webkit, type Page} from 'playwright';
-import type ky from '../source/index.js'; // eslint-disable-line import/no-duplicates
-import type {DownloadProgress} from '../source/index.js'; // eslint-disable-line import/no-duplicates
-import {createHttpTestServer, type ExtendedHttpTestServer, type HttpServerOptions} from './helpers/create-http-test-server.js';
-import {parseRawBody} from './helpers/parse-body.js';
-import {browserTest, defaultBrowsersTest} from './helpers/with-page.js';
+import type ky from '../source/index'; // eslint-disable-line import/no-duplicates
+import type {DownloadProgress} from '../source/index'; // eslint-disable-line import/no-duplicates
+import {createHttpTestServer, type ExtendedHttpTestServer, type HttpServerOptions} from './helpers/create-http-test-server';
+import {parseRawBody} from './helpers/parse-body';
+import {browserTest, defaultBrowsersTest} from './helpers/with-page';
 
 declare global {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -29,7 +29,7 @@ const createEsmTestServer = async (options?: HttpServerOptions) => {
 const KY_SCRIPT = {
 	type: 'module',
 	content: `
-		import ky from '/distribution/index.js';
+		import ky from '/distribution/index';
 		globalThis.ky = ky;
 	`,
 };

--- a/test/fetch.ts
+++ b/test/fetch.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import ky from '../source/index.js';
+import ky from '../source/index';
 
 const fixture = 'https://example.com/unicorn';
 

--- a/test/headers.ts
+++ b/test/headers.ts
@@ -2,8 +2,8 @@ import {Buffer} from 'node:buffer';
 import type {IncomingHttpHeaders} from 'node:http';
 import test from 'ava';
 import type {RequestHandler} from 'express';
-import ky from '../source/index.js';
-import {createHttpTestServer} from './helpers/create-http-test-server.js';
+import ky from '../source/index';
+import {createHttpTestServer} from './helpers/create-http-test-server';
 
 const timeout = 60_000;
 

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,3 +1,3 @@
-export * from './create-http-test-server.js';
-export * from './parse-body.js';
-export * from './with-page.js';
+export * from './create-http-test-server';
+export * from './parse-body';
+export * from './with-page';

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -1,8 +1,8 @@
 import test from 'ava';
 import delay from 'delay';
-import ky, {HTTPError} from '../source/index.js';
-import {type Options} from '../source/types/options.js';
-import {createHttpTestServer} from './helpers/create-http-test-server.js';
+import ky, {HTTPError} from '../source/index';
+import {type Options} from '../source/types/options';
+import {createHttpTestServer} from './helpers/create-http-test-server';
 
 test('hooks can be async', async t => {
 	const server = await createHttpTestServer();

--- a/test/http-error.ts
+++ b/test/http-error.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import {expectTypeOf} from 'expect-type';
-import {HTTPError} from '../source/index.js';
-import {type Mutable} from '../source/utils/types.js';
+import {HTTPError} from '../source/index';
+import {type Mutable} from '../source/utils/types';
 
 function createFakeResponse({status, statusText}: {status?: number; statusText?: string}): Response {
 	// Start with a realistic fetch Response.

--- a/test/main.ts
+++ b/test/main.ts
@@ -2,9 +2,9 @@ import {Buffer} from 'node:buffer';
 import test from 'ava';
 import delay from 'delay';
 import {expectTypeOf} from 'expect-type';
-import ky, {TimeoutError} from '../source/index.js';
-import {createHttpTestServer} from './helpers/create-http-test-server.js';
-import {parseRawBody} from './helpers/parse-body.js';
+import ky, {TimeoutError} from '../source/index';
+import {createHttpTestServer} from './helpers/create-http-test-server';
+import {parseRawBody} from './helpers/parse-body';
 
 const fixture = 'fixture';
 

--- a/test/methods.ts
+++ b/test/methods.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import ky from '../source/index.js';
-import {createHttpTestServer} from './helpers/create-http-test-server.js';
+import ky from '../source/index';
+import {createHttpTestServer} from './helpers/create-http-test-server';
 
 test('common method is normalized', async t => {
 	const server = await createHttpTestServer();

--- a/test/prefix-url.ts
+++ b/test/prefix-url.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
-import ky from '../source/index.js';
-import {createHttpTestServer} from './helpers/create-http-test-server.js';
+import ky from '../source/index';
+import {createHttpTestServer} from './helpers/create-http-test-server';
 
 test('prefixUrl option', async t => {
 	const server = await createHttpTestServer();

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
-import ky from '../source/index.js';
-import {createHttpTestServer} from './helpers/create-http-test-server.js';
-import {withPerformance} from './helpers/with-performance.js';
+import ky from '../source/index';
+import {createHttpTestServer} from './helpers/create-http-test-server';
+import {withPerformance} from './helpers/with-performance';
 
 const fixture = 'fixture';
 const defaultRetryCount = 2;

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -4,9 +4,9 @@
 		"sourceMap": true,
 		"inlineSources": true,
 		"rootDir": "./source",
-		"outDir": "./distribution"
+		"outDir": "./distribution",
+		"module": "ESNext",
+		"moduleResolution": "Bundler"
 	},
-	"include": [
-		"source"
-	]
+	"include": ["source"]
 }


### PR DESCRIPTION
Not a big change, but I've made it so there wouldn't be a need to add the ".js" extension to the end of each file import. To implement this change I've added minor changes to the tsconfig file, and added a few more eslint rules.