### PR TITLE
Fix memory leak from cloned responses

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -88,8 +88,7 @@ export class Ky {
 				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 				ky.request.headers.set('accept', ky.request.headers.get('accept') || mimeType);
 
-				const awaitedResult = await result;
-				const response = awaitedResult.clone();
+				const response = await result;
 
 				if (type === 'json') {
 					if (response.status === 204) {


### PR DESCRIPTION
Fixes #648

This removes an unnecessary response clone that was used in body method shortcuts, such as `ky().json()`, which caused the original response to be fully buffered and never consumed.