### PR TITLE
fix: throw early if signal is aborted before request is triggered

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -166,10 +166,10 @@ export class Ky {
 			if (originalSignal?.aborted) {
 				this.abortController.abort();
 			}
+
 			originalSignal?.addEventListener('abort', () => {
 				this.abortController!.abort(originalSignal.reason);
 			});
-
 			this._options.signal = this.abortController.signal;
 		}
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -164,7 +164,7 @@ export class Ky {
 			this.abortController = new globalThis.AbortController();
 			const originalSignal = this._options.signal ?? (this._input as Request).signal;
 			if (originalSignal?.aborted) {
-				this.abortController.abort();
+				this.abortController.abort(originalSignal?.reason);
 			}
 
 			originalSignal?.addEventListener('abort', () => {

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -163,6 +163,7 @@ export class Ky {
 		if (supportsAbortController) {
 			this.abortController = new globalThis.AbortController();
 			const originalSignal = this._options.signal ?? (this._input as Request).signal;
+			originalSignal?.throwIfAborted();
 			originalSignal?.addEventListener('abort', () => {
 				this.abortController!.abort(originalSignal.reason);
 			});

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -163,7 +163,9 @@ export class Ky {
 		if (supportsAbortController) {
 			this.abortController = new globalThis.AbortController();
 			const originalSignal = this._options.signal ?? (this._input as Request).signal;
-			originalSignal?.throwIfAborted();
+			if (originalSignal?.aborted) {
+				this.abortController.abort();
+			}
 			originalSignal?.addEventListener('abort', () => {
 				this.abortController!.abort(originalSignal.reason);
 			});

--- a/test/main.ts
+++ b/test/main.ts
@@ -716,7 +716,9 @@ test('throws DOMException/Error with name AbortError when aborted by user', asyn
 test('throws AbortError when signal was aborted before request', async t => {
 	const server = await createHttpTestServer();
 	let requestCount = 0;
-	server.get('/', () => {requestCount += 1;});
+	server.get('/', () => {
+		requestCount += 1;
+	});
 
 	const abortController = new AbortController();
 	const {signal} = abortController;
@@ -728,7 +730,7 @@ test('throws AbortError when signal was aborted before request', async t => {
 
 	t.true(['DOMException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
 	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
-	t.is(requestCount,0,"Request count is more than 0, server received request.");
+	t.is(requestCount, 0, 'Request count is more than 0, server received request.');
 });
 
 test('throws AbortError when aborted via Request', async t => {

--- a/test/main.ts
+++ b/test/main.ts
@@ -726,7 +726,6 @@ test('throws AbortError when signal was aborted before request', async t => {
 
 	const error = (await t.throwsAsync(response))!;
 
-
 	t.true(['DOMException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
 	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
 });

--- a/test/main.ts
+++ b/test/main.ts
@@ -713,6 +713,24 @@ test('throws DOMException/Error with name AbortError when aborted by user', asyn
 	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
 });
 
+test('throws AbortError when signal was aborted before request', async t => {
+	const server = await createHttpTestServer();
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	server.get('/', () => {});
+
+	const abortController = new AbortController();
+	const {signal} = abortController;
+	const request = new Request(server.url, {signal});
+	abortController.abort();
+	const response = ky(request);
+
+	const error = (await t.throwsAsync(response))!;
+
+
+	t.true(['DOMException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
+	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
+});
+
 test('throws AbortError when aborted via Request', async t => {
 	const server = await createHttpTestServer();
 	// eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/test/main.ts
+++ b/test/main.ts
@@ -715,8 +715,8 @@ test('throws DOMException/Error with name AbortError when aborted by user', asyn
 
 test('throws AbortError when signal was aborted before request', async t => {
 	const server = await createHttpTestServer();
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	server.get('/', () => {});
+	let requestCount = 0;
+	server.get('/', () => {requestCount += 1;});
 
 	const abortController = new AbortController();
 	const {signal} = abortController;
@@ -728,6 +728,7 @@ test('throws AbortError when signal was aborted before request', async t => {
 
 	t.true(['DOMException', 'Error'].includes(error.constructor.name), `Expected DOMException or Error, got ${error.constructor.name}`);
 	t.is(error.name, 'AbortError', `Expected AbortError, got ${error.name}`);
+	t.is(requestCount,0,"Request count is more than 0, server received request.");
 });
 
 test('throws AbortError when aborted via Request', async t => {


### PR DESCRIPTION
ky does not seem to abort a request if the signal was aborted before the request was triggered ([ref](https://github.com/sindresorhus/ky/issues/660)). 

We fix this by calling the `throwIfAborted()` method on the original signal.