### PR TITLE
fix: set default method to GET

### DIFF
--- a/source/utils/normalize.ts
+++ b/source/utils/normalize.ts
@@ -2,7 +2,7 @@ import {requestMethods} from '../core/constants.js';
 import type {HttpMethod} from '../types/options.js';
 import type {RetryOptions} from '../types/retry.js';
 
-export const normalizeRequestMethod = (input: string = 'GET'): string =>
+export const normalizeRequestMethod = (input = 'GET'): string =>
 	requestMethods.includes(input as HttpMethod) ? input.toUpperCase() : input;
 
 const retryMethods = ['get', 'put', 'head', 'delete', 'options', 'trace'];

--- a/source/utils/normalize.ts
+++ b/source/utils/normalize.ts
@@ -2,7 +2,7 @@ import {requestMethods} from '../core/constants.js';
 import type {HttpMethod} from '../types/options.js';
 import type {RetryOptions} from '../types/retry.js';
 
-export const normalizeRequestMethod = (input: string): string =>
+export const normalizeRequestMethod = (input: string = "GET"): string =>
 	requestMethods.includes(input as HttpMethod) ? input.toUpperCase() : input;
 
 const retryMethods = ['get', 'put', 'head', 'delete', 'options', 'trace'];

--- a/source/utils/normalize.ts
+++ b/source/utils/normalize.ts
@@ -2,7 +2,7 @@ import {requestMethods} from '../core/constants.js';
 import type {HttpMethod} from '../types/options.js';
 import type {RetryOptions} from '../types/retry.js';
 
-export const normalizeRequestMethod = (input: string = "GET"): string =>
+export const normalizeRequestMethod = (input: string = 'GET'): string =>
 	requestMethods.includes(input as HttpMethod) ? input.toUpperCase() : input;
 
 const retryMethods = ['get', 'put', 'head', 'delete', 'options', 'trace'];


### PR DESCRIPTION
In Chrome versions earlier than 64, making a fetch request with `method: undefined` results in an error because the browser interprets it as `Access-Control-Request-Method: undefined`.

```ts
fetch("url", {
  method: undefined
});
```

This PR introduces a fallback to "GET" when no method is provided, ensuring the request continues to work without errors.