### PR TITLE
fix: avoid set method undefined

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -135,7 +135,6 @@ export class Ky {
 				},
 				options.hooks,
 			),
-			method: normalizeRequestMethod(options.method ?? (this._input as Request).method),
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 			prefixUrl: String(options.prefixUrl || ''),
 			retry: normalizeRetryOptions(options.retry),
@@ -143,6 +142,12 @@ export class Ky {
 			timeout: options.timeout ?? 10_000,
 			fetch: options.fetch ?? globalThis.fetch.bind(globalThis),
 		};
+
+		const method = normalizeRequestMethod(options.method ?? (this._input as Request).method);
+
+		if (method !== undefined) {
+			this._options.method = method;
+		}
 
 		if (typeof this._input !== 'string' && !(this._input instanceof URL || this._input instanceof globalThis.Request)) {
 			throw new TypeError('`input` must be a string, URL, or Request');


### PR DESCRIPTION
In Chrome versions earlier than 64, making a fetch request with `method: undefined` results in an error because the browser interprets it as `Access-Control-Request-Method: undefined`.

```ts
fetch("url", {
  method: undefined
});
```

This version has less impact than [setting "GET" by default](https://github.com/sindresorhus/ky/pull/668). The method is set only if it is not undefined.