### PR TITLE
Fix options.method being undefined in normalized options

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -135,7 +135,7 @@ export class Ky {
 				},
 				options.hooks,
 			),
-			method: normalizeRequestMethod(options.method ?? (this._input as Request).method),
+			method: normalizeRequestMethod(options.method ?? (this._input as Request).method ?? 'GET'),
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 			prefixUrl: String(options.prefixUrl || ''),
 			retry: normalizeRetryOptions(options.retry),

--- a/test/methods.ts
+++ b/test/methods.ts
@@ -24,6 +24,29 @@ test('common method is normalized', async t => {
 	await server.close();
 });
 
+test('method defaults to "GET"', async t => {
+	const server = await createHttpTestServer();
+	server.all('/', (_request, response) => {
+		response.end();
+	});
+
+	t.plan(2);
+
+	await t.notThrowsAsync(
+		ky(server.url, {
+			hooks: {
+				beforeRequest: [
+					(_input, options) => {
+						t.is(options.method, 'GET');
+					},
+				],
+			},
+		}),
+	);
+
+	await server.close();
+});
+
 test.failing('custom method remains identical', async t => {
 	const server = await createHttpTestServer();
 	server.all('/', (_request, response) => {


### PR DESCRIPTION
Fix `options.method` (where `options` has the `NormalizedOptions` type) being `undefined` when no method is provided.

Fixes #670.