### PR TITLE
Improve reliability of cloned request cleanup

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -66,11 +66,6 @@ export class Ky {
 				throw error;
 			}
 
-			// Now that we know a retry is not needed, close the ReadableStream of the cloned request.
-			if (!ky.request.bodyUsed) {
-				await ky.request.body?.cancel();
-			}
-
 			// If `onDownloadProgress` is passed, it uses the stream API internally
 			if (ky._options.onDownloadProgress) {
 				if (typeof ky._options.onDownloadProgress !== 'function') {
@@ -88,7 +83,13 @@ export class Ky {
 		};
 
 		const isRetriableMethod = ky._options.retry.methods.includes(ky.request.method.toLowerCase());
-		const result = (isRetriableMethod ? ky._retry(function_) : function_()) as ResponsePromise;
+		const result = (isRetriableMethod ? ky._retry(function_) : function_())
+			.finally(async () => {
+				// Now that we know a retry is not needed, close the ReadableStream of the cloned request.
+				if (!ky.request.bodyUsed) {
+					await ky.request.body?.cancel();
+				}
+			}) as ResponsePromise;
 
 		for (const [type, mimeType] of Object.entries(responseTypes) as ObjectEntries<typeof responseTypes>) {
 			result[type] = async () => {


### PR DESCRIPTION
Fixes #690 

Prevents requests from hanging in certain cases by
1. Waiting until all retries are complete before cleaning up the final retry clone, rather than cleaning up each retry clone after each retry.
2. Cleaning up the retry clone even if there is an error.