### PR TITLE
bearer option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ It's just a tiny package with no dependencies.
 - JSON option
 - Timeout support
 - URL prefix option
+- Bearer option
 - Instances with custom defaults
 - Hooks
 - TypeScript niceties (e.g. `.json()` supports generics and defaults to `unknown`, not `any`)

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -146,6 +146,8 @@ export class Ky {
 			method: normalizeRequestMethod(options.method ?? (this._input as Request).method ?? 'GET'),
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 			prefixUrl: String(options.prefixUrl || ''),
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			bearer: String(options.bearer || ''),
 			retry: normalizeRetryOptions(options.retry),
 			throwHttpErrors: options.throwHttpErrors !== false,
 			timeout: options.timeout ?? 10_000,
@@ -166,6 +168,10 @@ export class Ky {
 			}
 
 			this._input = this._options.prefixUrl + this._input;
+		}
+
+		if (this._options.bearer) {
+			this._options.headers.set('authorization', `Bearer ${this._options.bearer}`);
 		}
 
 		if (supportsAbortController) {

--- a/source/core/constants.ts
+++ b/source/core/constants.ts
@@ -65,6 +65,7 @@ export const kyOptionKeys: KyOptionsRegistry = {
 	stringifyJson: true,
 	searchParams: true,
 	prefixUrl: true,
+	bearer: true,
 	retry: true,
 	timeout: true,
 	hooks: true,

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -38,6 +38,13 @@ export type KyOptions = {
 	json?: unknown;
 
 	/**
+	Shortcut for sending Authorization: Bearer <...>. Use this instead of the `headers` option.
+
+	Accepts any string, which will be sent with the correct header set.
+	 */
+	bearer?: string;
+
+	/**
 	User-defined JSON-parsing function.
 
 	Use-cases:
@@ -291,12 +298,13 @@ export interface Options extends KyOptions, Omit<RequestInit, 'headers'> { // es
 
 export type InternalOptions = Required<
 Omit<Options, 'hooks' | 'retry'>,
-'fetch' | 'prefixUrl' | 'timeout'
+'fetch' | 'prefixUrl' | 'bearer' | 'timeout'
 > & {
 	headers: Required<Headers>;
 	hooks: Required<Hooks>;
 	retry: Required<RetryOptions>;
 	prefixUrl: string;
+	bearer: string;
 };
 
 /**
@@ -310,6 +318,7 @@ export interface NormalizedOptions extends RequestInit { // eslint-disable-line 
 	// Extended from custom `KyOptions`, but ensured to be set (not optional).
 	retry: RetryOptions;
 	prefixUrl: string;
+	bearer: string;
 	onDownloadProgress: Options['onDownloadProgress'];
 	onUploadProgress: Options['onUploadProgress'];
 }

--- a/test/bearer.ts
+++ b/test/bearer.ts
@@ -1,0 +1,20 @@
+import type {IncomingHttpHeaders} from 'node:http';
+import test from 'ava';
+import type {RequestHandler} from 'express';
+import ky from '../source/index.js';
+import {createHttpTestServer} from './helpers/create-http-test-server.js';
+
+const echoHeaders: RequestHandler = (request, response) => {
+	request.resume();
+	response.end(JSON.stringify(request.headers));
+};
+
+test('`user-agent`', async t => {
+	const server = await createHttpTestServer();
+	server.get('/', echoHeaders);
+
+	const headers = await ky.get(server.url, {
+		bearer: 'awesome',
+	}).json<IncomingHttpHeaders>();
+	t.is(headers.authorization, 'Bearer awesome');
+});


### PR DESCRIPTION
I use ky almost every day at work. And I'm constantly annoyed by having to manually write headers for bearer tokens.

So I made this option, as I think it will be convenient to use.

I'm a bad developer, so sorry if the implementation is not as good as the other code in this library.

The main goal is to have a convenient thing.