### PR TITLE
beforeReturn hook

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -2,32 +2,33 @@
 
 import {Ky} from './core/Ky.js';
 import {requestMethods, stop} from './core/constants.js';
-import type {KyInstance} from './types/ky.js';
+import type {GetTypedReturnKyInstance} from './types/ky.js';
 import type {Input, Options} from './types/options.js';
 import {validateAndMerge} from './utils/merge.js';
-import {type Mutable} from './utils/types.js';
 
-const createInstance = (defaults?: Partial<Options>): KyInstance => {
+const createInstance = <T extends Partial<Options>>(defaults?: T): GetTypedReturnKyInstance<T> => {
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
-	const ky: Partial<Mutable<KyInstance>> = (input: Input, options?: Options) => Ky.create(input, validateAndMerge(defaults, options));
+	const ky = (input: Input, options?: Partial<Options>) => Ky.create(input, validateAndMerge(defaults, options));
 
 	for (const method of requestMethods) {
+		// TS is a headache here because of generic values and stuff; type casting of return value is the only thing that really matters anyway
+		// @ts-expect-error
 		// eslint-disable-next-line @typescript-eslint/promise-function-async
-		ky[method] = (input: Input, options?: Options) => Ky.create(input, validateAndMerge(defaults, options, {method}));
+		ky[method] = (input: Input, options?: Partial<Options>) => Ky.create(input, validateAndMerge(defaults, options, {method}));
 	}
 
-	ky.create = (newDefaults?: Partial<Options>) => createInstance(validateAndMerge(newDefaults));
-	ky.extend = (newDefaults?: Partial<Options> | ((parentDefaults: Partial<Options>) => Partial<Options>)) => {
+	ky.create = <K extends Partial<Options>>(newDefaults?: K) => createInstance<K>(validateAndMerge(newDefaults) as K);
+	ky.extend = <K extends Partial<Options>>(newDefaults?: K | ((parentDefaults: T | Record<string | number | symbol, unknown>) => K)) => {
 		if (typeof newDefaults === 'function') {
 			newDefaults = newDefaults(defaults ?? {});
 		}
 
-		return createInstance(validateAndMerge(defaults, newDefaults));
+		return createInstance(validateAndMerge(defaults, newDefaults) as K & T) as GetTypedReturnKyInstance<K & T>;
 	};
 
 	ky.stop = stop;
 
-	return ky as KyInstance;
+	return ky as GetTypedReturnKyInstance<T>;
 };
 
 const ky = createInstance();

--- a/source/utils/merge.ts
+++ b/source/utils/merge.ts
@@ -40,6 +40,7 @@ export const mergeHooks = (original: Hooks = {}, incoming: Hooks = {}): Required
 		beforeRetry: newHookValue(original, incoming, 'beforeRetry'),
 		afterResponse: newHookValue(original, incoming, 'afterResponse'),
 		beforeError: newHookValue(original, incoming, 'beforeError'),
+		beforeReturn: newHookValue(original, incoming, 'beforeReturn'),
 	}
 );
 


### PR DESCRIPTION
Hi! This is a proof of concept PR for a `beforeReturn` hook (discussed in #696) that is less strict about return type than `afterResponse` . 
*Important note*: this PR at least needs some work to be done in terms of types, although basic usage is fully covered. 

**Why** ❔ :
- more flexible approach than current implementation of `afterResponse`
- no overhead associated with JSON de-, serialization  when using `beforeReturn` opposed to `afterResponse`

**Key usage points** 🔑 :
-  if specified, the return of last `beforeReturn` callback is what gets returned by ky
-  `beforeReturn` is called at the end of hook life-cycle
-  `beforeReturn` is not called if request is erroneous and `throwHttpErrors` is not off
-  `beforeReturn` allows any return from callback
-  in case of a sequence of `beforeReturn` callbacks (`{ beforeReturn: [cb1, cb2, ... ] }`) each subsequent callback is invoked with the result of the previous callback invocation

**Potential workflow** ➡️  :
As I see it, `afterResponse` can be used to perform additional network operations based on a response (combine multiple requests together, simply send additional requests, or even some exotic retry logic that needs some customized behavior); whereas `beforeReturn` can be used to ensure consistency of the returned value. Basically, `afterResponse` is for anything that actually alters the Response, `beforeReturn` is to derive data from Response

**Key developing points** 🖊️ :
- most changes are within TypeScript domain, actual JavaScript is small
- in order to flexibly type the return value , in case of using `beforeReturn`, it is required to infer return type from last `beforeReturn` cb
- `extend` and the `options` argument for ky methods require to consider type collisions among them and `beforeReturn` exit value

**Misc**:
While TypeScript-related code is kind of unattractive, it is still the required minimum to derive return type from `Options`, in a sense that anything else in `Options` that affects the returned value would need the same approach to reflect it through types

**PR progress state** 🚧  :
Waiting for comments whether the idea is welcomed

Thanks for taking time to review my PR!!
 