### PR TITLE
Workaround silent crash in node 20 on await stream cancel

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -87,7 +87,7 @@ export class Ky {
 			.finally(async () => {
 				// Now that we know a retry is not needed, close the ReadableStream of the cloned request.
 				if (!ky.request.bodyUsed) {
-					await ky.request.body?.cancel();
+					ky.request.body?.cancel();
 				}
 			}) as ResponsePromise;
 


### PR DESCRIPTION
Just an observation, maybe this is not an actual fix. On Node.js 20, awaiting promise returned from ReadableStream cancel silently crashes the process.