### PR TITLE
chore: update readme on got differences

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -737,7 +737,7 @@ console.log(json.title);
 
 #### How is it different from [`got`](https://github.com/sindresorhus/got)
 
-See my answer [here](https://twitter.com/sindresorhus/status/1037406558945042432). Got is maintained by the same people as Ky.
+Got is maintained by the same people as Ky, so you probably want Ky instead. It's smaller, works in the browser too, and is more stable since it's built on Fetch.
 
 #### How is it different from [`axios`](https://github.com/axios/axios)?
 


### PR DESCRIPTION
Stealing part of the readme from got package. I believe the tweet is no longer valid and now Ky works also server side, and it's preferred over got