### PR TITLE
Don't produce URL with "?" alone

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -14,7 +14,7 @@ import {normalizeRequestMethod, normalizeRetryOptions} from '../utils/normalize.
 import timeout, {type TimeoutOptions} from '../utils/timeout.js';
 import delay from '../utils/delay.js';
 import {type ObjectEntries} from '../utils/types.js';
-import {findUnknownOptions} from '../utils/options.js';
+import {findUnknownOptions, isNonEmptySearchParameters} from '../utils/options.js';
 import {
 	maxSafeTimeout,
 	responseTypes,
@@ -186,7 +186,7 @@ export class Ky {
 
 		this.request = new globalThis.Request(this._input, this._options);
 
-		if (this._options.searchParams) {
+		if (isNonEmptySearchParameters(this._options.searchParams)) {
 			// eslint-disable-next-line unicorn/prevent-abbreviations
 			const textSearchParams = typeof this._options.searchParams === 'string'
 				? this._options.searchParams.replace(/^\?/, '')

--- a/source/utils/options.ts
+++ b/source/utils/options.ts
@@ -1,4 +1,5 @@
 import {kyOptionKeys, requestOptionsRegistry} from '../core/constants.js';
+import type {SearchParamsOption} from '../types/options.js';
 
 export const findUnknownOptions = (
 	request: Request,
@@ -13,4 +14,26 @@ export const findUnknownOptions = (
 	}
 
 	return unknownOptions;
+};
+
+export const isNonEmptySearchParameters = (search: SearchParamsOption): boolean => {
+	if (search === undefined) {
+		return false;
+	}
+
+	// The `typeof array` still gives "object", so we need different checking for array.
+	if (Array.isArray(search)) {
+		return search.length > 0;
+	}
+
+	// Record and URLSearchParams
+	if (typeof search === 'object') {
+		return Object.keys(search).length > 0;
+	}
+
+	if (typeof search === 'string') {
+		return search.trim().length > 0;
+	}
+
+	return Boolean(search);
 };

--- a/test/fetch.ts
+++ b/test/fetch.ts
@@ -4,7 +4,7 @@ import ky from '../source/index.js';
 const fixture = 'https://example.com/unicorn';
 
 test('fetch option takes a custom fetch function', async t => {
-	t.plan(6);
+	t.plan(9);
 
 	const customFetch: typeof fetch = async input => {
 		if (!(input instanceof Request)) {
@@ -21,6 +21,27 @@ test('fetch option takes a custom fetch function', async t => {
 			searchParams: {foo: 'bar'},
 		}).text(),
 		`${fixture}?foo=bar`,
+	);
+	t.is(
+		await ky(fixture, {
+			fetch: customFetch,
+			searchParams: {},
+		}).text(),
+		`${fixture}`,
+	);
+	t.is(
+		await ky(fixture, {
+			fetch: customFetch,
+			searchParams: [],
+		}).text(),
+		`${fixture}`,
+	);
+	t.is(
+		await ky(fixture, {
+			fetch: customFetch,
+			searchParams: '  ',
+		}).text(),
+		`${fixture}`,
 	);
 	t.is(
 		await ky(`${fixture}#hash`, {


### PR DESCRIPTION
When the `searchParams` is an empty project, `ky` still produce URL with question mark, like "/path?". It should be without "?".
This PR is to fix that.