### PR TITLE
Add Node 20 and latest to CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 24
+          - latest
           - 22
           - 20
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 24
           - 22
+          - 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/test/headers.ts
+++ b/test/headers.ts
@@ -1,4 +1,5 @@
 import {Buffer} from 'node:buffer';
+import process from 'node:process';
 import type {IncomingHttpHeaders} from 'node:http';
 import test from 'ava';
 import type {RequestHandler} from 'express';
@@ -251,10 +252,14 @@ test('form-data sets `content-length` header', async t => {
 	const form = new FormData();
 	form.append('a', 'b');
 
-	// @ts-expect-error FormData type mismatch
 	const headers = await ky.post(server.url, {body: form}).json<IncomingHttpHeaders>();
 
-	t.is(headers['content-length'], '119');
+	// Node 24 added some linebreaks to the end of the serialized FormData
+	if (Number.parseInt(process.versions.node, 10) < 24) {
+		t.is(headers['content-length'], '119');
+	} else {
+		t.is(headers['content-length'], '121');
+	}
 });
 
 test('buffer as `options.body` sets `content-length` header', async t => {


### PR DESCRIPTION
This PR ensures that the CI tests run on all [currently supported versions](https://nodejs.org/en/about/previous-releases#nodejs-releases) of Node to help catch upstream bugs, like the one discussed in #689.