### PR TITLE
Fix race condition issue with `.json()`

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -112,15 +112,16 @@ export class Ky {
 						return '';
 					}
 
-					const arrayBuffer = await response.clone().arrayBuffer();
-					const responseSize = arrayBuffer.byteLength;
-					if (responseSize === 0) {
+					const text = await response.text();
+					if (text === '') {
 						return '';
 					}
 
 					if (options.parseJson) {
-						return options.parseJson(await response.text());
+						return options.parseJson(text);
 					}
+
+					return JSON.parse(text);
 				}
 
 				return response[type]();


### PR DESCRIPTION
This is a potential fix for #719. Even if it's not, it's still a nice simplification. So for that reason, I'm not going to wait for OP of #719 to test it out first.

Since it's not reproducible, I was not able to add a test.