### PR TITLE
Use nullish coalescing for error title option

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -166,6 +166,7 @@ export class Ky {
 				options.hooks,
 			),
 			method: normalizeRequestMethod(options.method ?? (this._input as Request).method ?? 'GET'),
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 			prefixUrl: String(options.prefixUrl || ''),
 			retry: normalizeRetryOptions(options.retry),
 			throwHttpErrors: options.throwHttpErrors !== false,


### PR DESCRIPTION
Replace logical OR with nullish coalescing operator to better handle falsy values and adhere to TypeScript best practices.