### PR TITLE
Remove unnecessary double Request wrapping in searchParams handling

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -244,8 +244,8 @@ export class Ky {
 			const searchParams = '?' + textSearchParams;
 			const url = this.request.url.replace(/(?:\?.*?)?(?=#|$)/, searchParams);
 
-			// The spread of `this.request` is required as otherwise it misses the `duplex` option for some reason and throws.
-			this.request = new globalThis.Request(new globalThis.Request(url, {...this.request}), this.#options as RequestInit);
+			// Recreate request with the updated URL. We already have all options in this.#options, including duplex.
+			this.request = new globalThis.Request(url, this.#options as RequestInit);
 		}
 
 		// If `onUploadProgress` is passed, it uses the stream API internally


### PR DESCRIPTION
The spread operator `{...this.request}` in the `searchParams` handling code returns an empty object because Request properties are not enumerable; they are getters on the prototype. This means the double Request wrapping pattern was effectively:

```js
new Request(new Request(url, {}), this.#options)
```