### PR TITLE
Allow `beforeRetry` hooks to return a `Request` or `Response`

### DIFF
--- a/source/types/hooks.ts
+++ b/source/types/hooks.ts
@@ -27,7 +27,7 @@ export type BeforeRetryState = {
 	*/
 	retryCount: number;
 };
-export type BeforeRetryHook = (options: BeforeRetryState) => typeof stop | void | Promise<typeof stop | void>;
+export type BeforeRetryHook = (options: BeforeRetryState) => Request | Response | typeof stop | void | Promise<Request | Response | typeof stop | void>;
 
 export type AfterResponseState = {
 	/**
@@ -90,9 +90,13 @@ export type Hooks = {
 	/**
 	This hook enables you to modify the request right before retry. Ky will make no further changes to the request after this. The hook function receives an object with the normalized request and options, an error instance, and the retry count. You could, for example, modify `request.headers` here.
 
+	The hook can return a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) to replace the outgoing retry request, or return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) to skip the retry and use that response instead. **Note:** Returning a request or response skips remaining `beforeRetry` hooks.
+
 	If the request received a response, the error will be of type `HTTPError` and the `Response` object will be available at `error.response`. Be aware that some types of errors, such as network errors, inherently mean that a response was not received. In that case, the error will not be an instance of `HTTPError`.
 
 	You can prevent Ky from retrying the request by throwing an error. Ky will not handle it in any way and the error will be propagated to the request initiator. The rest of the `beforeRetry` hooks will not be called in this case. Alternatively, you can return the [`ky.stop`](#ky.stop) symbol to do the same thing but without propagating an error (this has some limitations, see `ky.stop` docs for details).
+
+	**Modifying headers:**
 
 	@example
 	```
@@ -103,7 +107,50 @@ export type Hooks = {
 			beforeRetry: [
 				async ({request, options, error, retryCount}) => {
 					const token = await ky('https://example.com/refresh-token');
-					options.headers.set('Authorization', `token ${token}`);
+					request.headers.set('Authorization', `token ${token}`);
+				}
+			]
+		}
+	});
+	```
+
+	**Modifying the request URL:**
+
+	@example
+	```
+	import ky from 'ky';
+
+	const response = await ky('https://example.com/api', {
+		hooks: {
+			beforeRetry: [
+				async ({request, error}) => {
+					// Add query parameters based on error response
+					if (error.response) {
+						const body = await error.response.json();
+						const url = new URL(request.url);
+						url.searchParams.set('processId', body.processId);
+						return new Request(url, request);
+					}
+				}
+			]
+		}
+	});
+	```
+
+	**Returning a cached response:**
+
+	@example
+	```
+	import ky from 'ky';
+
+	const response = await ky('https://example.com/api', {
+		hooks: {
+			beforeRetry: [
+				({error, retryCount}) => {
+					// Use cached response instead of retrying
+					if (retryCount > 1 && cachedResponse) {
+						return cachedResponse;
+					}
 				}
 			]
 		}


### PR DESCRIPTION
Fixes #297