### PR TITLE
Fix Next.js edge runtime `next` option support

### DIFF
--- a/source/core/constants.ts
+++ b/source/core/constants.ts
@@ -78,6 +78,13 @@ export const kyOptionKeys: KyOptionsRegistry = {
 	context: true,
 };
 
+// Vendor-specific fetch options that should always be passed to fetch()
+// even if they appear on the Request object due to vendor patching.
+// See: https://github.com/sindresorhus/ky/issues/541
+export const vendorSpecificOptions = {
+	next: true, // Next.js cache revalidation (revalidate, tags)
+} as const;
+
 // Standard RequestInit options that should NOT be passed separately to fetch()
 // because they're already applied to the Request object.
 // Note: `dispatcher` and `priority` are NOT included here - they're fetch-only

--- a/source/utils/options.ts
+++ b/source/utils/options.ts
@@ -1,4 +1,4 @@
-import {kyOptionKeys, requestOptionsRegistry} from '../core/constants.js';
+import {kyOptionKeys, requestOptionsRegistry, vendorSpecificOptions} from '../core/constants.js';
 import type {SearchParamsOption} from '../types/options.js';
 
 export const findUnknownOptions = (
@@ -8,7 +8,18 @@ export const findUnknownOptions = (
 	const unknownOptions: Record<string, unknown> = {};
 
 	for (const key in options) {
-		if (!(key in requestOptionsRegistry) && !(key in kyOptionKeys) && !(key in request)) {
+		// Skip inherited properties
+		if (!Object.hasOwn(options, key)) {
+			continue;
+		}
+
+		// An option is passed to fetch() if:
+		// 1. It's not a standard RequestInit option (not in requestOptionsRegistry)
+		// 2. It's not a ky-specific option (not in kyOptionKeys)
+		// 3. Either:
+		//    a. It's not on the Request object, OR
+		//    b. It's a vendor-specific option that should always be passed (in vendorSpecificOptions)
+		if (!(key in requestOptionsRegistry) && !(key in kyOptionKeys) && (!(key in request) || key in vendorSpecificOptions)) {
 			unknownOptions[key] = options[key];
 		}
 	}


### PR DESCRIPTION
Fixes #541

---

I considered many ways to fix this, but simply hard-coding `next` for this extreme edge-case is the safest and simplest solution.