### PR TITLE
Allow `throwHttpErrors` option to be a function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -533,12 +533,14 @@ const response = await ky('https://example.com', {
 
 ##### throwHttpErrors
 
-Type: `boolean`\
+Type: `boolean | (status: number) => boolean`\
 Default: `true`
 
 Throw an `HTTPError` when, after following redirects, the response has a non-2xx status code. To also throw for redirects instead of following them, set the [`redirect`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters) option to `'manual'`.
 
 Setting this to `false` may be useful if you are checking for resource availability and are expecting error responses.
+
+You can also pass a function that accepts the HTTP status code and returns a boolean for selective error handling. Note that this can violate the principle of least surprise, so it's recommended to use the boolean form unless you have a specific use case like treating 404 responses differently.
 
 Note: If `false`, error responses are considered successful and the request will not be retried.
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -59,7 +59,11 @@ export class Ky {
 
 			ky.#decorateResponse(response);
 
-			if (!response.ok && ky.#options.throwHttpErrors) {
+			if (!response.ok && (
+				typeof ky.#options.throwHttpErrors === 'function'
+					? ky.#options.throwHttpErrors(response.status)
+					: ky.#options.throwHttpErrors
+			)) {
 				let error = new HTTPError(response, ky.request, ky.#getNormalizedOptions());
 
 				for (const hook of ky.#options.hooks.beforeError) {
@@ -184,7 +188,7 @@ export class Ky {
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 			prefixUrl: String(options.prefixUrl || ''),
 			retry: normalizeRetryOptions(options.retry),
-			throwHttpErrors: options.throwHttpErrors !== false,
+			throwHttpErrors: options.throwHttpErrors ?? true,
 			timeout: options.timeout ?? 10_000,
 			fetch: options.fetch ?? globalThis.fetch.bind(globalThis),
 			context: options.context ?? {},

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -163,11 +163,13 @@ export type KyOptions = {
 
 	Setting this to `false` may be useful if you are checking for resource availability and are expecting error responses.
 
+	You can also pass a function that accepts the HTTP status code and returns a boolean for selective error handling. Note that this can violate the principle of least surprise, so it's recommended to use the boolean form unless you have a specific use case like treating 404 responses differently.
+
 	Note: If `false`, error responses are considered successful and the request will not be retried.
 
 	@default true
 	*/
-	throwHttpErrors?: boolean;
+	throwHttpErrors?: boolean | ((status: number) => boolean);
 
 	/**
 	Download progress event handler.
@@ -353,7 +355,7 @@ export interface Options extends KyOptions, Omit<RequestInit, 'headers'> { // es
 }
 
 export type InternalOptions = Required<
-Omit<Options, 'hooks' | 'retry' | 'context'>,
+Omit<Options, 'hooks' | 'retry' | 'context' | 'throwHttpErrors'>,
 'fetch' | 'prefixUrl' | 'timeout'
 > & {
 	headers: Required<Headers>;
@@ -361,6 +363,7 @@ Omit<Options, 'hooks' | 'retry' | 'context'>,
 	retry: Required<Omit<RetryOptions, 'shouldRetry'>> & Pick<RetryOptions, 'shouldRetry'>;
 	prefixUrl: string;
 	context: Record<string, unknown>;
+	throwHttpErrors: boolean | ((status: number) => boolean);
 };
 
 /**


### PR DESCRIPTION
Fixes #780