### PR TITLE
Improve type safety in test file

### DIFF
--- a/test/memory-leak.ts
+++ b/test/memory-leak.ts
@@ -36,9 +36,7 @@ test('shared abort signal must not cause memory leak of input', async t => {
 
 test('failed stream request must not cause memory leak', async t => {
 	async function isStreamLeaking() {
-		const stream: ReadableStream | undefined = ReadableStream.from([
-			new TextEncoder().encode('Bell is Ringing.'),
-		]);
+		const stream: ReadableStream | undefined = ReadableStream.from([new TextEncoder().encode('Bell is Ringing.')]);
 		const detector = new LeakDetector(stream);
 
 		await t.throwsAsync(


### PR DESCRIPTION
I add type assertion to resolve conflict between Node.js stream/web ReadableStream and DOM ReadableStream types. The test runs in Node.js but ky uses DOM types for cross-platform compatibility.

I attached a screenshot of type error

<img width="1142" height="480" alt="image" src="https://github.com/user-attachments/assets/7da56e03-98dc-48a5-ae60-88e37da340ab" />
