### PR TITLE
Strip Ky-specific properties from normalized options passed to hooks

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -691,7 +691,19 @@ export class Ky {
 
 	#getNormalizedOptions(): NormalizedOptions {
 		if (!this.#cachedNormalizedOptions) {
-			const {hooks, ...normalizedOptions} = this.#options;
+			// Exclude Ky-specific options that are not part of `RequestInit`.
+			const {
+				hooks,
+				json,
+				parseJson,
+				stringifyJson,
+				searchParams,
+				timeout,
+				throwHttpErrors,
+				fetch,
+				...normalizedOptions
+			} = this.#options;
+
 			this.#cachedNormalizedOptions = Object.freeze(normalizedOptions) as NormalizedOptions;
 		}
 

--- a/test/http-error.ts
+++ b/test/http-error.ts
@@ -170,14 +170,14 @@ test('HTTPError#data does not hang when async parseJson never resolves', async t
 	const error = await t.throwsAsync<HTTPError>(ky('https://example.com', {
 		fetch: customFetch,
 		retry: 0,
-		timeout: 50,
+		timeout: 500,
 		parseJson: async () => new Promise<never>(resolve => {
 			void resolve;
 		}),
 	}));
 	t.true(error instanceof HTTPError);
 	t.is(error?.data, undefined);
-	t.true(Date.now() - start < 2000);
+	t.true(Date.now() - start < 5000);
 });
 
 test('HTTPError#data does not call parseJson for non-JSON responses', async t => {

--- a/test/main.ts
+++ b/test/main.ts
@@ -525,45 +525,6 @@ test('throwHttpErrors function - selective error handling', async t => {
 	);
 });
 
-test('throwHttpErrors preserves original type in hooks', async t => {
-	const server = await createHttpTestServer(t);
-
-	server.get('/', (_request, response) => {
-		response.sendStatus(200);
-	});
-
-	// Test that boolean is preserved
-	let booleanTypeInHook: unknown;
-	await ky.get(server.url, {
-		throwHttpErrors: false,
-		hooks: {
-			beforeRequest: [
-				({options}) => {
-					booleanTypeInHook = options.throwHttpErrors;
-				},
-			],
-		},
-	});
-	t.is(typeof booleanTypeInHook, 'boolean');
-	t.is(booleanTypeInHook, false);
-
-	// Test that function is preserved
-	let functionTypeInHook: unknown;
-	const throwFunction = (status: number) => status >= 500;
-	await ky.get(server.url, {
-		throwHttpErrors: throwFunction,
-		hooks: {
-			beforeRequest: [
-				({options}) => {
-					functionTypeInHook = options.throwHttpErrors;
-				},
-			],
-		},
-	});
-	t.is(typeof functionTypeInHook, 'function');
-	t.is(functionTypeInHook, throwFunction);
-});
-
 test('ky.create()', async t => {
 	const server = await createHttpTestServer(t);
 	server.get('/', (request, response) => {


### PR DESCRIPTION
They were already stripped in types, but not in JS.

See #762