### PR TITLE
Add Standard Schema validation for `json()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,27 @@ const user2 = await ky<User>('/api/users/2').json();
 const user3 = await ky('/api/users/3').json<User>();
 
 console.log([user1, user2, user3]);
+```
 
+You can also get the response body as JSON and validate it with a Standard Schema compatible validator (for example, Zod 3.24+). This throws a `SchemaValidationError` when validation fails.
+
+```ts
+import ky, {SchemaValidationError} from 'ky';
+import {z} from 'zod';
+
+const userSchema = z.object({name: z.string()});
+
+try {
+	const user = await ky('/api/user').json(userSchema);
+	console.log(user.name);
+} catch (error) {
+	if (error instanceof SchemaValidationError) {
+		console.error(error.issues);
+	}
+}
+```
+
+```ts
 // Get raw bytes (when supported by the runtime)
 const bytes = await ky('/api/file').bytes();
 console.log(bytes instanceof Uint8Array);
@@ -1060,6 +1080,9 @@ Base class for all Ky-specific errors. `HTTPError`, `TimeoutError`, and `ForceRe
 
 You can use `instanceof KyError` to check if an error originated from Ky, or use the `isKyError()` type guard for cross-realm compatibility and TypeScript type narrowing.
 
+> [!NOTE]
+> `SchemaValidationError` is intentionally not considered a Ky error. `KyError` covers failures in Ky's HTTP lifecycle (bad status, timeout, retry), while schema validation errors originate from the user-provided schema, not from Ky itself.
+
 ```js
 import ky, {isKyError} from 'ky';
 
@@ -1116,6 +1139,28 @@ await ky('https://example.com', {
 ```
 
 ⌨️ **TypeScript:** Accepts an optional [type parameter](https://www.typescriptlang.org/docs/handbook/2/generics.html), which defaults to [`unknown`](https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown), and is passed through to the type of `error.data`.
+
+### SchemaValidationError
+
+The error thrown when [Standard Schema](https://github.com/standard-schema/standard-schema) validation fails in `.json(schema)`. It has an `issues` property with the validation issues from the schema.
+
+This error intentionally does not extend `KyError` because it does not represent a failure in Ky's HTTP lifecycle. The request succeeded; the user's schema rejected the data. As such, it is not matched by `isKyError()`.
+
+```js
+import ky, {SchemaValidationError} from 'ky';
+import {z} from 'zod';
+
+const userSchema = z.object({name: z.string()});
+
+try {
+	const user = await ky('/api/user').json(userSchema);
+	console.log(user.name);
+} catch (error) {
+	if (error instanceof SchemaValidationError) {
+		console.error(error.issues);
+	}
+}
+```
 
 ### TimeoutError
 

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -1,6 +1,7 @@
 import {HTTPError} from '../errors/HTTPError.js';
 import {NonError} from '../errors/NonError.js';
 import {ForceRetryError} from '../errors/ForceRetryError.js';
+import {SchemaValidationError} from '../errors/SchemaValidationError.js';
 import {TimeoutError} from '../errors/TimeoutError.js';
 import type {
 	Input,
@@ -11,6 +12,7 @@ import type {
 	SearchParamsOption,
 } from '../types/options.js';
 import {type ResponsePromise} from '../types/ResponsePromise.js';
+import type {StandardSchemaV1} from '../types/standard-schema.js';
 import {streamRequest, streamResponse} from '../utils/body.js';
 import {mergeHeaders, mergeHooks} from '../utils/merge.js';
 import {normalizeRequestMethod, normalizeRetryOptions} from '../utils/normalize.js';
@@ -44,6 +46,36 @@ const createTextDecoder = (contentType: string): TextDecoder => {
 	}
 
 	return new TextDecoder();
+};
+
+const validateJsonWithSchema = async (jsonValue: unknown, schema: StandardSchemaV1): Promise<unknown> => {
+	if (
+		(
+			typeof schema !== 'object'
+			&& typeof schema !== 'function'
+		)
+		|| schema === null
+	) {
+		throw new TypeError('The `schema` argument must follow the Standard Schema specification');
+	}
+
+	const standardSchema = schema['~standard'];
+
+	if (
+		typeof standardSchema !== 'object'
+		|| standardSchema === null
+		|| typeof standardSchema.validate !== 'function'
+	) {
+		throw new TypeError('The `schema` argument must follow the Standard Schema specification');
+	}
+
+	const validationResult = await standardSchema.validate(jsonValue);
+
+	if (validationResult.issues) {
+		throw new SchemaValidationError(validationResult.issues);
+	}
+
+	return validationResult.value;
 };
 
 export class Ky {
@@ -195,32 +227,26 @@ export class Ky {
 				continue;
 			}
 
-			result[type] = async () => {
+			result[type] = async (schema?: StandardSchemaV1) => {
 				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 				ky.request.headers.set('accept', ky.request.headers.get('accept') || mimeType);
 
 				const response = await result;
 
-				if (type === 'json') {
-					// Ky intentionally returns `undefined` for 204/empty bodies on the shortcut for
-					// ergonomic "no content" handling.
-					if (response.status === 204) {
-						return undefined;
-					}
-
-					const text = await response.text();
-					if (text === '') {
-						return undefined;
-					}
-
-					if (options.parseJson) {
-						return options.parseJson(text);
-					}
-
-					return JSON.parse(text);
+				if (type !== 'json') {
+					return response[type]();
 				}
 
-				return response[type]();
+				const text = response.status === 204 ? '' : await response.text();
+				if (text === '') {
+					return schema === undefined ? undefined : validateJsonWithSchema(undefined, schema);
+				}
+
+				const jsonValue = options.parseJson
+					? await options.parseJson(text)
+					: JSON.parse(text);
+
+				return schema === undefined ? jsonValue : validateJsonWithSchema(jsonValue, schema);
 			};
 		}
 

--- a/source/errors/SchemaValidationError.ts
+++ b/source/errors/SchemaValidationError.ts
@@ -1,0 +1,33 @@
+import type {StandardSchemaV1Issue} from '../types/standard-schema.js';
+
+/**
+Thrown when a response body fails validation against a user-provided Standard Schema.
+
+This error intentionally does not extend `KyError` because it does not represent a failure in Ky's HTTP lifecycle. The request succeeded; the user's schema rejected the data. As such, it is not matched by `isKyError()`.
+
+@example
+```
+import ky, {SchemaValidationError} from 'ky';
+import {z} from 'zod';
+
+const userSchema = z.object({name: z.string()});
+
+try {
+	const user = await ky('/api/user').json(userSchema);
+	console.log(user.name);
+} catch (error) {
+	if (error instanceof SchemaValidationError) {
+		console.error(error.issues);
+	}
+}
+```
+*/
+export class SchemaValidationError extends Error {
+	override name = 'SchemaValidationError' as const;
+	readonly issues: readonly StandardSchemaV1Issue[];
+
+	constructor(issues: readonly StandardSchemaV1Issue[]) {
+		super('Response schema validation failed');
+		this.issues = issues;
+	}
+}

--- a/source/index.ts
+++ b/source/index.ts
@@ -60,10 +60,16 @@ export type {
 } from './types/hooks.js';
 
 export type {ResponsePromise} from './types/ResponsePromise.js';
+export type {
+	StandardSchemaV1,
+	StandardSchemaV1InferOutput,
+	StandardSchemaV1Issue,
+} from './types/standard-schema.js';
 export type {KyRequest} from './types/request.js';
 export type {KyResponse} from './types/response.js';
 export {KyError} from './errors/KyError.js';
 export {HTTPError} from './errors/HTTPError.js';
+export {SchemaValidationError} from './errors/SchemaValidationError.js';
 export {TimeoutError} from './errors/TimeoutError.js';
 export {ForceRetryError} from './errors/ForceRetryError.js';
 export {

--- a/source/types/ResponsePromise.ts
+++ b/source/types/ResponsePromise.ts
@@ -2,6 +2,7 @@
 Returns a `Response` object with `Body` methods added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`; these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return `undefined` if body is empty or the response status is `204` instead of throwing a parse error due to an empty body.
 */
 import {type KyResponse} from './response.js';
+import type {StandardSchemaV1, StandardSchemaV1InferOutput} from './standard-schema.js';
 
 export type ResponsePromise<T = unknown> = {
 	arrayBuffer: () => Promise<ArrayBuffer>;
@@ -19,30 +20,50 @@ export type ResponsePromise<T = unknown> = {
 
 	// TODO: Use `json<T extends JSONValue>(): Promise<T>;` when it's fixed in TS.
 	// See https://github.com/microsoft/TypeScript/issues/15300 and https://github.com/sindresorhus/ky/pull/80
-	/**
-	Get the response body as JSON.
+	json: {
+		/**
+		Get the response body as JSON.
 
-	@example
-	```
-	import ky from 'ky';
+		@example
+		```
+		import ky from 'ky';
 
-	const json = await ky(…).json();
-	```
+		const json = await ky(…).json();
+		```
 
-	@example
-	```
-	import ky from 'ky';
+		@example
+		```
+		import ky from 'ky';
 
-	interface Result {
-		value: number;
-	}
+		interface Result {
+			value: number;
+		}
 
-	const result1 = await ky(…).json<Result>();
-	// or
-	const result2 = await ky<Result>(…).json();
-	```
-	*/
-	json: <J = T>() => Promise<J | undefined>;
+		const result1 = await ky(…).json<Result>();
+		// or
+		const result2 = await ky<Result>(…).json();
+		```
+		*/
+		<JsonType = T>(): Promise<JsonType | undefined>;
+
+		/**
+		Get the response body as JSON and validate it with a Standard Schema.
+		Use a Standard Schema compatible validator (for example, Zod 3.24+).
+
+		Throws a `SchemaValidationError` when validation fails.
+
+		@example
+		```
+		import ky from 'ky';
+		import {z} from 'zod';
+
+		const userSchema = z.object({name: z.string()});
+
+		const user = await ky('/api/user').json(userSchema);
+		```
+		*/
+		<Schema extends StandardSchemaV1>(schema: Schema): Promise<StandardSchemaV1InferOutput<Schema>>;
+	};
 
 	text: () => Promise<string>;
 } & Promise<KyResponse<T>>;

--- a/source/types/standard-schema.ts
+++ b/source/types/standard-schema.ts
@@ -1,0 +1,48 @@
+export type StandardSchemaV1Issue = {
+	readonly message: string;
+	readonly path?: ReadonlyArray<PropertyKey | {readonly key: PropertyKey}> | undefined;
+};
+
+export type StandardSchemaV1SuccessResult<OutputType> = {
+	readonly value: OutputType;
+	readonly issues?: undefined;
+};
+
+export type StandardSchemaV1FailureResult = {
+	readonly issues: readonly StandardSchemaV1Issue[];
+	readonly value?: undefined;
+};
+
+export type StandardSchemaV1Result<OutputType> = StandardSchemaV1SuccessResult<OutputType> | StandardSchemaV1FailureResult;
+
+export type StandardSchemaV1Types<InputType, OutputType> = {
+	readonly input: InputType;
+	readonly output: OutputType;
+};
+
+export type StandardSchemaV1Options = {
+	readonly libraryOptions?: Readonly<Record<string, unknown>> | undefined;
+};
+
+export type StandardSchemaV1<InputType = unknown, OutputType = InputType> = {
+	readonly '~standard': {
+		readonly version: 1;
+		readonly vendor: string;
+		readonly validate: (
+			value: unknown,
+			options?: StandardSchemaV1Options,
+		) => StandardSchemaV1Result<OutputType> | Promise<StandardSchemaV1Result<OutputType>>;
+		readonly types?: StandardSchemaV1Types<InputType, OutputType> | undefined;
+	};
+};
+
+export type StandardSchemaV1InferOutput<Schema extends StandardSchemaV1> = Schema['~standard'] extends {
+	readonly types: StandardSchemaV1Types<unknown, infer OutputType>;
+}
+	? OutputType
+	: Extract<
+		Awaited<ReturnType<Schema['~standard']['validate']>>,
+		StandardSchemaV1SuccessResult<unknown>
+	> extends StandardSchemaV1SuccessResult<infer OutputType>
+		? OutputType
+		: unknown;

--- a/source/utils/type-guards.ts
+++ b/source/utils/type-guards.ts
@@ -6,6 +6,8 @@ import {ForceRetryError} from '../errors/ForceRetryError.js';
 /**
 Type guard to check if an error is a Ky error.
 
+Note: `SchemaValidationError` is intentionally not considered a Ky error. `KyError` covers failures in Ky's HTTP lifecycle (bad status, timeout, retry), while schema validation errors originate from the user-provided schema, not from Ky itself.
+
 @param error - The error to check
 @returns `true` if the error is a Ky error, `false` otherwise
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -2,11 +2,47 @@ import {Buffer} from 'node:buffer';
 import {setTimeout as delay} from 'node:timers/promises';
 import test from 'ava';
 import {expectTypeOf} from 'expect-type';
-import ky, {HTTPError, TimeoutError} from '../source/index.js';
+import ky, {
+	HTTPError,
+	SchemaValidationError,
+	TimeoutError,
+	isKyError,
+	type StandardSchemaV1,
+} from '../source/index.js';
 import {createHttpTestServer} from './helpers/create-http-test-server.js';
 import {parseRawBody} from './helpers/parse-body.js';
 
 const fixture = 'fixture';
+
+type TestSchemaResult<Output> = {value: Output} | {issues: Array<{message: string}>};
+
+const createSchema = <Output>(
+	validate: (value: unknown) => TestSchemaResult<Output> | Promise<TestSchemaResult<Output>>,
+): StandardSchemaV1<unknown, Output> => ({
+	'~standard': {
+		version: 1,
+		vendor: 'test',
+		validate,
+	},
+});
+
+const isObjectWithValue = (value: unknown): value is {value: unknown} => (
+	typeof value === 'object'
+	&& value !== null
+	&& 'value' in value
+);
+
+const createSchemaCallTracker = () => {
+	let isSchemaCalled = false;
+
+	return {
+		schema: createSchema(() => {
+			isSchemaCalled = true;
+			return {value: {value: 1}};
+		}),
+		isSchemaCalled: () => isSchemaCalled,
+	};
+};
 
 test('ky()', async t => {
 	const server = await createHttpTestServer(t);
@@ -303,6 +339,305 @@ test('.json() with empty body does not call parseJson', async t => {
 
 	t.is(result, undefined);
 	t.false(parseJsonCalled);
+});
+
+test('.json(schema) returns validated output and infers type', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: 1});
+	});
+
+	const schema = createSchema<{value: number}>(value => {
+		if (
+			isObjectWithValue(value)
+			&& typeof value.value === 'number'
+		) {
+			return {value: {value: value.value}};
+		}
+
+		return {issues: [{message: 'Expected {value:number}'}]};
+	});
+
+	const responseJson = await ky.get(server.url).json(schema);
+
+	expectTypeOf(responseJson).toEqualTypeOf<{value: number}>();
+	t.deepEqual(responseJson, {value: 1});
+});
+
+test('.json(schema) accepts schema with typed input generic', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json('1');
+	});
+
+	const schema: StandardSchemaV1<string, number> = {
+		'~standard': {
+			version: 1,
+			vendor: 'test',
+			validate(value) {
+				if (typeof value === 'string') {
+					return {value: Number(value)};
+				}
+
+				return {issues: [{message: 'Expected string'}]};
+			},
+		},
+	};
+
+	const responseJson = await ky.get(server.url).json(schema);
+
+	expectTypeOf(responseJson).toEqualTypeOf<number>();
+	t.is(responseJson, 1);
+});
+
+test('.json(schema) accepts callable schema objects', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: 1});
+	});
+
+	const schema: StandardSchemaV1<unknown, {value: number}> = Object.assign(
+		() => undefined,
+		{
+			'~standard': {
+				version: 1 as const,
+				vendor: 'test',
+				validate(value: unknown) {
+					if (
+						isObjectWithValue(value)
+						&& typeof value.value === 'number'
+					) {
+						return {value: {value: value.value}};
+					}
+
+					return {issues: [{message: 'Expected {value:number}'}]};
+				},
+			},
+		},
+	);
+
+	const responseJson = await ky.get(server.url).json(schema);
+
+	t.deepEqual(responseJson, {value: 1});
+});
+
+test('.json(schema) throws SchemaValidationError when validation fails', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: 'invalid'});
+	});
+
+	const issues = [{message: 'Expected {value:number}'}];
+	const schema = createSchema<{value: number}>(() => ({issues}));
+
+	const error = await t.throwsAsync(ky.get(server.url).json(schema), {
+		instanceOf: SchemaValidationError,
+		message: 'Response schema validation failed',
+	});
+
+	t.false(isKyError(error));
+	t.deepEqual(error?.issues, issues);
+});
+
+test('.json(schema) throws TypeError for invalid schema objects', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: 1});
+	});
+
+	const invalidSchema = {'~standard': {}} as unknown as StandardSchemaV1;
+
+	await t.throwsAsync(ky.get(server.url).json(invalidSchema), {
+		instanceOf: TypeError,
+		message: 'The `schema` argument must follow the Standard Schema specification',
+	});
+});
+
+test('.json(schema) throws TypeError for null schema values', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: 1});
+	});
+
+	const invalidSchema = null as unknown as StandardSchemaV1;
+
+	await t.throwsAsync(ky.get(server.url).json(invalidSchema), {
+		instanceOf: TypeError,
+		message: 'The `schema` argument must follow the Standard Schema specification',
+	});
+});
+
+test('.json(schema) allows schema output transformations', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: '1'});
+	});
+
+	const schema = createSchema<{value: number}>(value => {
+		if (
+			isObjectWithValue(value)
+			&& typeof value.value === 'string'
+		) {
+			return {value: {value: Number(value.value)}};
+		}
+
+		return {issues: [{message: 'Expected {value:string}'}]};
+	});
+
+	const responseJson = await ky.get(server.url).json(schema);
+
+	t.deepEqual(responseJson, {value: 1});
+});
+
+test('.json(schema) supports async validation', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: 1});
+	});
+
+	const schema = createSchema<{value: number}>(async value => {
+		await delay(1);
+
+		if (
+			isObjectWithValue(value)
+			&& typeof value.value === 'number'
+		) {
+			return {value: {value: value.value}};
+		}
+
+		return {issues: [{message: 'Expected {value:number}'}]};
+	});
+
+	const responseJson = await ky.get(server.url).json(schema);
+
+	t.deepEqual(responseJson, {value: 1});
+});
+
+test('.json(schema) validates empty body values as undefined', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.end();
+	});
+
+	const issues = [{message: 'Expected non-empty JSON'}];
+	let validatedValue: unknown = Symbol('unset');
+	const schema = createSchema<unknown>(value => {
+		validatedValue = value;
+		return {issues};
+	});
+
+	const error = await t.throwsAsync(ky.get(server.url).json(schema), {
+		instanceOf: SchemaValidationError,
+		message: 'Response schema validation failed',
+	});
+
+	t.is(validatedValue, undefined);
+	t.deepEqual(error?.issues, issues);
+});
+
+test('.json(schema) validates 204 responses as undefined', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.status(204).end();
+	});
+
+	const issues = [{message: 'Expected non-empty JSON'}];
+	let validatedValue: unknown = Symbol('unset');
+	const schema = createSchema<unknown>(value => {
+		validatedValue = value;
+		return {issues};
+	});
+
+	const error = await t.throwsAsync(ky.get(server.url).json(schema), {
+		instanceOf: SchemaValidationError,
+		message: 'Response schema validation failed',
+	});
+
+	t.is(validatedValue, undefined);
+	t.deepEqual(error?.issues, issues);
+});
+
+test('.json(schema) with invalid JSON body throws parse error before validation', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.end('not json');
+	});
+
+	const {schema, isSchemaCalled} = createSchemaCallTracker();
+
+	await t.throwsAsync(ky.get(server.url).json(schema), {
+		message: /Unexpected token/,
+	});
+
+	t.false(isSchemaCalled());
+});
+
+test('.json(schema) does not run validation for HTTP errors', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.status(500).json({value: 1});
+	});
+
+	const {schema, isSchemaCalled} = createSchemaCallTracker();
+
+	await t.throwsAsync(ky.get(server.url).json(schema), {
+		instanceOf: HTTPError,
+	});
+
+	t.false(isSchemaCalled());
+});
+
+test('.json(schema) accepts empty body when schema validates it', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.end();
+	});
+
+	const schema = createSchema<string>(value => ({
+		value: value === undefined ? 'empty:undefined' : 'non-empty',
+	}));
+
+	const responseJson = await ky.get(server.url).json(schema);
+
+	t.is(responseJson, 'empty:undefined');
+});
+
+test('.json(schema) runs validation when throwHttpErrors is false', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.status(500).json({error: 'server error'});
+	});
+
+	const schema = createSchema<{error: string}>(value => {
+		if (
+			typeof value === 'object'
+			&& value !== null
+			&& 'error' in value
+		) {
+			return {value: value as {error: string}};
+		}
+
+		return {issues: [{message: 'Expected {error:string}'}]};
+	});
+
+	const responseJson = await ky.get(server.url, {throwHttpErrors: false}).json(schema);
+
+	t.deepEqual(responseJson, {error: 'server error'});
+});
+
+test('.json(schema) propagates errors thrown by validate()', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: 1});
+	});
+
+	const schema = createSchema<unknown>(() => {
+		throw new Error('validate exploded');
+	});
+
+	await t.throwsAsync(ky.get(server.url).json(schema), {
+		message: 'validate exploded',
+	});
 });
 
 test('timeout option', async t => {
@@ -1021,6 +1356,59 @@ test('parseJson option with promise.json() shortcut', async t => {
 		...json,
 		extra: 'extraValue',
 	});
+});
+
+test('parseJson option runs before .json(schema) validation', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: '1'});
+	});
+
+	const schema = createSchema<{value: number}>(value => {
+		if (
+			isObjectWithValue(value)
+			&& typeof value.value === 'number'
+		) {
+			return {value: {value: value.value}};
+		}
+
+		return {issues: [{message: 'Expected parsed number'}]};
+	});
+
+	const responseJson = await ky
+		.get(server.url, {
+			parseJson(text) {
+				const parsed = JSON.parse(text) as {value: string};
+				return {value: Number(parsed.value)};
+			},
+		})
+		.json(schema);
+
+	t.deepEqual(responseJson, {value: 1});
+});
+
+test('parseJson option errors are thrown before .json(schema) validation', async t => {
+	const server = await createHttpTestServer(t);
+	server.get('/', (_request, response) => {
+		response.json({value: '1'});
+	});
+
+	const {schema, isSchemaCalled} = createSchemaCallTracker();
+
+	await t.throwsAsync(
+		ky
+			.get(server.url, {
+				parseJson() {
+					throw new Error('parseJson failed');
+				},
+			})
+			.json(schema),
+		{
+			message: 'parseJson failed',
+		},
+	);
+
+	t.false(isSchemaCalled());
 });
 
 test('stringifyJson option with request.json()', async t => {


### PR DESCRIPTION
Fixes #730

---

I'm still not convinced we should add this, but I thought I would implement it just to see what it would look like.