### PR TITLE
Fix `beforeRequest` hooks being skipped when a `Request` is returned

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -351,7 +351,7 @@ This hook enables you to modify the request right before it is sent. Ky will mak
 
 The `retryCount` is `0` for the initial request and increments with each retry. This allows you to distinguish between initial requests and retries, which is useful when you need different behavior for retries (e.g., avoiding overwriting headers set in `beforeRetry`).
 
-The hook can return a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) to replace the outgoing request, or return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) to completely avoid making an HTTP request. This can be used to mock a request, check an internal cache, etc. An **important** consideration when returning a request or response from this hook is that any remaining `beforeRequest` hooks will be skipped, so you may want to only return them from the last hook.
+The hook can return a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) to replace the outgoing request (remaining hooks will still run with the updated request). It can also return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) to completely avoid making an HTTP request, in which case remaining `beforeRequest` hooks are skipped. This can be used to mock a request, check an internal cache, etc.
 
 ```js
 import ky from 'ky';

--- a/source/types/hooks.ts
+++ b/source/types/hooks.ts
@@ -65,7 +65,7 @@ export type Hooks = {
 
 	The `retryCount` is `0` for the initial request and increments with each retry. This allows you to distinguish between initial requests and retries, which is useful when you need different behavior for retries (e.g., avoiding overwriting headers set in `beforeRetry`).
 
-	A [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) can be returned from this hook to completely avoid making an HTTP request. This can be used to mock a request, check an internal cache, etc. An **important** consideration when returning a `Response` from this hook is that all the following hooks will be skipped, so **ensure you only return a `Response` from the last hook**.
+	A [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) can be returned from this hook to replace the outgoing request; remaining hooks will still run with the updated request. A [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) can be returned to completely avoid making an HTTP request, in which case remaining `beforeRequest` hooks are skipped. This can be used to mock a request, check an internal cache, etc.
 
 	@example
 	```

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -69,6 +69,444 @@ test('POST JSON with upload progress', async t => {
 	);
 });
 
+test('multiple beforeRequest Request hooks do not duplicate upload progress events', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	server.post('/', async (request, response) => {
+		response.json(await parseJsonBody<Record<string, unknown>>(request));
+	});
+
+	let completedUploadProgressEvents = 0;
+	const payload = {test: 'test'};
+	const responseJson = await ky
+		.post(server.url, {
+			json: payload,
+			hooks: {
+				beforeRequest: [
+					({request}) => {
+						const headers = new Headers(request.headers);
+						headers.set('x-hook-1', 'hook-1');
+						return new Request(request, {headers});
+					},
+					({request}) => {
+						const headers = new Headers(request.headers);
+						headers.set('x-hook-2', 'hook-2');
+						return new Request(request, {headers});
+					},
+				],
+			},
+			onUploadProgress(progress) {
+				if (progress.percent === 1) {
+					completedUploadProgressEvents++;
+				}
+			},
+		})
+		.json<Record<string, unknown>>();
+
+	t.deepEqual(responseJson, payload);
+	t.is(completedUploadProgressEvents, 1);
+});
+
+test('multiple beforeRequest Request hooks do not duplicate upload progress events across retries', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	let requestCount = 0;
+	server.post('/', async (request, response) => {
+		requestCount++;
+		if (requestCount === 1) {
+			response.status(500).json({error: 'retry'});
+			return;
+		}
+
+		response.json(await parseJsonBody<Record<string, unknown>>(request));
+	});
+
+	const completedUploadProgressEventsPerAttempt: number[] = [];
+	const payload = {test: 'retry'};
+	const responseJson = await ky
+		.post(server.url, {
+			json: payload,
+			retry: {
+				limit: 1,
+				methods: ['post'],
+			},
+			hooks: {
+				beforeRequest: [
+					({request}) => {
+						completedUploadProgressEventsPerAttempt.push(0);
+						const headers = new Headers(request.headers);
+						headers.set('x-hook-1', 'hook-1');
+						return new Request(request, {headers});
+					},
+					({request}) => {
+						const headers = new Headers(request.headers);
+						headers.set('x-hook-2', 'hook-2');
+						return new Request(request, {headers});
+					},
+				],
+			},
+			onUploadProgress(progress) {
+				if (progress.percent !== 1) {
+					return;
+				}
+
+				const currentAttemptIndex = completedUploadProgressEventsPerAttempt.length - 1;
+				completedUploadProgressEventsPerAttempt[currentAttemptIndex]++;
+			},
+		})
+		.json<Record<string, unknown>>();
+
+	t.deepEqual(responseJson, payload);
+	t.deepEqual(completedUploadProgressEventsPerAttempt, [1, 1]);
+});
+
+test('beforeRequest Request replacement preserves upload progress sizing', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	server.post('/', async (request, response) => {
+		let totalBytes = 0;
+		for await (const chunk of request) {
+			totalBytes += chunk.length as number;
+		}
+
+		response.json({receivedBytes: totalBytes});
+	});
+
+	const largeBlob = createLargeBlob(10);
+	const progressEvents: Progress[] = [];
+	const response = await ky
+		.post(server.url, {
+			body: largeBlob,
+			hooks: {
+				beforeRequest: [
+					({request}) => {
+						const headers = new Headers(request.headers);
+						headers.set('x-hook', '1');
+						return new Request(request, {headers});
+					},
+				],
+			},
+			onUploadProgress(progress) {
+				progressEvents.push(progress);
+			},
+		})
+		.json<{receivedBytes: number}>();
+
+	t.true(progressEvents.length >= 2, 'Should produce multiple progress events');
+	const nonFinalProgressEvents = progressEvents.filter(progress => progress.percent < 1);
+	t.true(nonFinalProgressEvents.length > 0, 'Should include non-final progress events');
+	for (const progress of nonFinalProgressEvents) {
+		const expectedPercent = progress.transferredBytes / largeBlob.size;
+		t.true(progress.percent <= expectedPercent + 0.01, 'Intermediate progress should reflect known body size');
+	}
+
+	const finalProgress = progressEvents.at(-1);
+	t.truthy(finalProgress);
+	t.is(finalProgress!.percent, 1);
+	t.true(finalProgress!.totalBytes > 1024 * 1024);
+	t.is(finalProgress!.totalBytes, finalProgress!.transferredBytes);
+	t.is(response.receivedBytes, finalProgress!.totalBytes);
+});
+
+test('beforeRequest Request replacement with new body preserves upload progress sizing', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	server.post('/', async (request, response) => {
+		let receivedBytes = 0;
+		for await (const chunk of request) {
+			receivedBytes += chunk.length as number;
+		}
+
+		response.json({receivedBytes});
+	});
+
+	const payload = {initial: true};
+	const replacementBody = createLargeBlob(10);
+	const progressEvents: Progress[] = [];
+	const response = await ky
+		.post(server.url, {
+			json: payload,
+			hooks: {
+				beforeRequest: [
+					({request}) => new Request(request, {body: replacementBody}),
+				],
+			},
+			onUploadProgress(progress) {
+				progressEvents.push(progress);
+			},
+		})
+		.json<{receivedBytes: number}>();
+
+	t.true(progressEvents.length > 0, 'Should produce progress events');
+	const expectedSize = replacementBody.size;
+	const finalProgress = progressEvents.at(-1);
+	t.truthy(finalProgress);
+	t.is(finalProgress!.percent, 1);
+	t.is(finalProgress!.totalBytes, expectedSize);
+	t.is(finalProgress!.transferredBytes, expectedSize);
+	t.is(response.receivedBytes, expectedSize);
+});
+
+test('missing content-length still uses original body size for upload progress', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	server.post('/', async (request, response) => {
+		let receivedBytes = 0;
+		for await (const chunk of request) {
+			receivedBytes += chunk.length as number;
+		}
+
+		response.json({receivedBytes});
+	});
+
+	const body = createLargeBlob(10);
+	const progressEvents: Progress[] = [];
+	const response = await ky
+		.post(server.url, {
+			body,
+			hooks: {
+				beforeRequest: [
+					({request}) => {
+						request.headers.delete('content-length');
+					},
+				],
+			},
+			onUploadProgress(progress) {
+				progressEvents.push(progress);
+			},
+		})
+		.json<{receivedBytes: number}>();
+
+	t.true(progressEvents.length >= 2, 'Should produce multiple progress events');
+	const nonFinalProgressEvents = progressEvents.filter(progress => progress.percent < 1);
+	t.true(nonFinalProgressEvents.length > 0, 'Should include non-final progress events');
+	t.true(nonFinalProgressEvents[0].percent > 0, 'Non-final progress should use known total size');
+
+	const finalProgress = progressEvents.at(-1);
+	t.truthy(finalProgress);
+	t.is(finalProgress!.percent, 1);
+	t.is(finalProgress!.totalBytes, body.size);
+	t.is(finalProgress!.transferredBytes, body.size);
+	t.is(response.receivedBytes, body.size);
+});
+
+test('beforeRequest replacement with smaller body completes upload progress correctly', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	server.post('/', async (request, response) => {
+		let receivedBytes = 0;
+		for await (const chunk of request) {
+			receivedBytes += chunk.length as number;
+		}
+
+		response.json({receivedBytes});
+	});
+
+	const originalBody = createLargeBlob(10);
+	const replacementBody = 'small-body';
+	const replacementBodySize = Buffer.byteLength(replacementBody);
+	const progressEvents: Progress[] = [];
+	const response = await ky
+		.post(server.url, {
+			body: originalBody,
+			hooks: {
+				beforeRequest: [
+					({request}) => new Request(request, {body: replacementBody}),
+				],
+			},
+			onUploadProgress(progress) {
+				progressEvents.push(progress);
+			},
+		})
+		.json<{receivedBytes: number}>();
+
+	t.true(progressEvents.length > 0, 'Should produce progress events');
+	const nonFinalProgressEvents = progressEvents.filter(progress => progress.percent < 1);
+	for (const progress of nonFinalProgressEvents) {
+		t.true(progress.percent < 1, 'Intermediate progress should stay below completion');
+	}
+
+	const finalProgress = progressEvents.at(-1);
+	t.truthy(finalProgress);
+	t.is(finalProgress!.percent, 1);
+	t.is(finalProgress!.transferredBytes, replacementBodySize);
+	t.is(response.receivedBytes, replacementBodySize);
+});
+
+test('beforeRequest replacement with larger body has monotonic upload progress', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	server.post('/', async (request, response) => {
+		let receivedBytes = 0;
+		for await (const chunk of request) {
+			receivedBytes += chunk.length as number;
+		}
+
+		response.json({receivedBytes});
+	});
+
+	const replacementBody = createLargeBlob(10);
+	const progressEvents: Progress[] = [];
+	const response = await ky
+		.post(server.url, {
+			body: 'tiny',
+			hooks: {
+				beforeRequest: [
+					({request}) => new Request(request, {body: replacementBody}),
+				],
+			},
+			onUploadProgress(progress) {
+				progressEvents.push(progress);
+			},
+		})
+		.json<{receivedBytes: number}>();
+
+	t.true(progressEvents.length > 0, 'Should produce progress events');
+	for (let index = 1; index < progressEvents.length; index++) {
+		t.true(progressEvents[index].transferredBytes >= progressEvents[index - 1].transferredBytes, 'Transferred bytes should be monotonic');
+		t.true(progressEvents[index].percent >= progressEvents[index - 1].percent, 'Percent should be monotonic');
+	}
+
+	const finalProgress = progressEvents.at(-1);
+	t.truthy(finalProgress);
+	t.is(finalProgress!.percent, 1);
+	t.is(finalProgress!.transferredBytes, replacementBody.size);
+	t.is(response.receivedBytes, replacementBody.size);
+});
+
+test('beforeRequest body replacement followed by header hook keeps progress and headers', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	server.post('/', async (request, response) => {
+		let receivedBytes = 0;
+		for await (const chunk of request) {
+			receivedBytes += chunk.length as number;
+		}
+
+		response.json({
+			receivedBytes,
+			header: request.headers['x-hook-2'],
+		});
+	});
+
+	const replacementBody = 'hook-replacement-body';
+	const replacementBodySize = Buffer.byteLength(replacementBody);
+	const progressEvents: Progress[] = [];
+	const response = await ky
+		.post(server.url, {
+			body: createLargeBlob(10),
+			hooks: {
+				beforeRequest: [
+					({request}) => new Request(request, {body: replacementBody}),
+					({request}) => {
+						const headers = new Headers(request.headers);
+						headers.set('x-hook-2', 'true');
+						return new Request(request, {headers});
+					},
+				],
+			},
+			onUploadProgress(progress) {
+				progressEvents.push(progress);
+			},
+		})
+		.json<{receivedBytes: number; header: string | undefined}>();
+
+	const finalProgress = progressEvents.at(-1);
+	t.truthy(finalProgress);
+	t.is(finalProgress!.percent, 1);
+	t.is(finalProgress!.transferredBytes, replacementBodySize);
+	t.is(response.receivedBytes, replacementBodySize);
+	t.is(response.header, 'true');
+});
+
+test('retry with beforeRequest body changes tracks per-attempt upload progress', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	let requestCount = 0;
+	server.post('/', async (_request, response) => {
+		requestCount++;
+		if (requestCount === 1) {
+			response.status(500).json({error: 'retry'});
+			return;
+		}
+
+		response.status(200).json({ok: true});
+	});
+
+	const firstAttemptBody = 'first-attempt';
+	const secondAttemptBody = 'second-attempt-body';
+	const firstAttemptBodySize = Buffer.byteLength(firstAttemptBody);
+	const secondAttemptBodySize = Buffer.byteLength(secondAttemptBody);
+	const eventsByAttempt: Progress[][] = [];
+	let currentAttempt = 0;
+
+	await ky.post(server.url, {
+		body: 'initial',
+		retry: {
+			limit: 1,
+			methods: ['post'],
+		},
+		hooks: {
+			beforeRequest: [
+				({request, retryCount}) => {
+					currentAttempt = retryCount;
+					eventsByAttempt[currentAttempt] = [];
+					const body = retryCount === 0 ? firstAttemptBody : secondAttemptBody;
+					return new Request(request, {body});
+				},
+			],
+		},
+		onUploadProgress(progress) {
+			eventsByAttempt[currentAttempt].push(progress);
+		},
+	}).json();
+
+	t.is(eventsByAttempt.length, 2);
+	const firstAttemptFinalProgress = eventsByAttempt[0].at(-1);
+	const secondAttemptFinalProgress = eventsByAttempt[1].at(-1);
+	t.truthy(firstAttemptFinalProgress);
+	t.truthy(secondAttemptFinalProgress);
+	t.is(firstAttemptFinalProgress!.percent, 1);
+	t.is(secondAttemptFinalProgress!.percent, 1);
+	t.is(firstAttemptFinalProgress!.transferredBytes, firstAttemptBodySize);
+	t.is(secondAttemptFinalProgress!.transferredBytes, secondAttemptBodySize);
+	t.is(eventsByAttempt[0].filter(progress => progress.percent === 1).length, 1);
+	t.is(eventsByAttempt[1].filter(progress => progress.percent === 1).length, 1);
+});
+
+test('ReadableStream upload emits stable non-final progress and completes once', async t => {
+	const server = await createHttpTestServer(t, {bodyParser: false});
+	server.post('/', async (request, response) => {
+		let receivedBytes = 0;
+		for await (const chunk of request) {
+			receivedBytes += chunk.length as number;
+		}
+
+		response.json({receivedBytes});
+	});
+
+	const streamBody = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode('chunk-1'));
+			controller.enqueue(new TextEncoder().encode('chunk-2'));
+			controller.close();
+		},
+	});
+
+	const progressEvents: Progress[] = [];
+	const response = await ky
+		.post(server.url, {
+			body: streamBody,
+			onUploadProgress(progress) {
+				progressEvents.push(progress);
+			},
+		})
+		.json<{receivedBytes: number}>();
+
+	t.true(progressEvents.length > 0, 'Should emit upload progress');
+	const nonFinalProgressEvents = progressEvents.filter(progress => progress.percent < 1);
+	t.true(nonFinalProgressEvents.length > 0, 'Should emit non-final progress');
+	for (const progress of nonFinalProgressEvents) {
+		t.true(progress.percent >= 0 && progress.percent < 1, 'Non-final progress should be within [0, 1)');
+	}
+
+	const completedProgressEvents = progressEvents.filter(progress => progress.percent === 1);
+	t.is(completedProgressEvents.length, 1, 'Should complete exactly once');
+	const finalProgress = completedProgressEvents[0];
+	t.is(finalProgress.transferredBytes, response.receivedBytes);
+});
+
 test('onDownloadProgress cancels original response body', async t => {
 	let originalResponse: Response | undefined;
 	let didReportProgress = false;


### PR DESCRIPTION
Fixes #387