### PR TITLE
Add `request` and `options` to `beforeError` hook state

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -522,19 +522,19 @@ const response = await ky('https://example.com/api', {
 Type: `Function[]`\
 Default: `[]`
 
-This hook enables you to modify any error right before it is thrown. The hook function receives a state object with an error and retry count, and should return an `Error` instance.
+This hook enables you to modify any error right before it is thrown. The hook function receives a state object with the request, options, error, and retry count, and should return an `Error` instance.
 
 This hook is called for all error types, including `HTTPError`, `TimeoutError`, `ForceRetryError` (when retry limit is exceeded via `ky.retry()`), and network errors. Use type guards like `isHTTPError()` or `isTimeoutError()` to handle specific error types.
 
 The `retryCount` is `0` for the initial request and increments with each retry. This allows you to distinguish between the initial request and retries, which is useful when you need different error handling based on retry attempts (e.g., showing different error messages on the final attempt).
 
 ```js
-import ky, {isHTTPError, isTimeoutError} from 'ky';
+import ky, {isHTTPError} from 'ky';
 
 await ky('https://example.com', {
 	hooks: {
 		beforeError: [
-			({error}) => {
+			({request, options, error}) => {
 				if (isHTTPError(error)) {
 					if (
 						typeof error.data === 'object'
@@ -546,9 +546,8 @@ await ky('https://example.com', {
 					}
 				}
 
-				if (isTimeoutError(error)) {
-					error.message = `Request to ${error.request.url} timed out`;
-				}
+				// `request` and `options` are always available
+				console.log(`Request to ${request.url} failed`, options.context);
 
 				return error;
 			}

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -187,6 +187,8 @@ export class Ky {
 				for (const hook of ky.#options.hooks.beforeError) {
 					// eslint-disable-next-line no-await-in-loop
 					const hookResult: unknown = await hook({
+						request: ky.request,
+						options: ky.#getNormalizedOptions(),
 						error: processedError,
 						retryCount: ky.#retryCount,
 					});

--- a/source/types/hooks.ts
+++ b/source/types/hooks.ts
@@ -43,6 +43,9 @@ export type AfterResponseState = {
 export type AfterResponseHook = (state: AfterResponseState) => Response | RetryMarker | void | Promise<Response | RetryMarker | void>;
 
 export type BeforeErrorState = {
+	request: KyRequest;
+	options: NormalizedOptions;
+
 	// `Error` (not `KyError`) because this receives all errors, including non-Ky ones like network `TypeError`s.
 	error: Error;
 
@@ -257,7 +260,7 @@ export type Hooks = {
 	afterResponse?: AfterResponseHook[];
 
 	/**
-	This hook enables you to modify any error right before it is thrown. The hook function receives a state object with an error and retry count, and should return an `Error` instance.
+	This hook enables you to modify any error right before it is thrown. The hook function receives a state object with the request, options, error, and retry count, and should return an `Error` instance.
 
 	This hook is called for all error types, including `HTTPError`, `TimeoutError`, `ForceRetryError` (when retry limit is exceeded via `ky.retry()`), and network errors. Use type guards like `isHTTPError()` or `isTimeoutError()` to handle specific error types.
 
@@ -267,12 +270,12 @@ export type Hooks = {
 
 	@example
 	```
-	import ky, {isHTTPError, isTimeoutError} from 'ky';
+	import ky, {isHTTPError} from 'ky';
 
 	await ky('https://example.com', {
 		hooks: {
 			beforeError: [
-				({error}) => {
+				({request, options, error}) => {
 					if (isHTTPError(error)) {
 						if (
 							typeof error.data === 'object'
@@ -284,9 +287,8 @@ export type Hooks = {
 						}
 					}
 
-					if (isTimeoutError(error)) {
-						error.message = `Request to ${error.request.url} timed out`;
-					}
+					// `request` and `options` are always available
+					console.log(`Request to ${request.url} failed`, options.context);
 
 					return error;
 				}

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -8,7 +8,7 @@ import ky, {
 	isForceRetryError,
 	TimeoutError,
 } from '../source/index.js';
-import {type Options} from '../source/types/options.js';
+import {type Options, type NormalizedOptions} from '../source/types/options.js';
 import {createHttpTestServer} from './helpers/create-http-test-server.js';
 
 const withHeader = (request: Request, name: string, value: string) => {
@@ -1942,6 +1942,141 @@ test('beforeError hook is not called when throwHttpErrors is false', async t => 
 
 	t.is(response.status, 500);
 	t.false(hookCalled);
+});
+
+test('beforeError receives request and options for HTTPError', async t => {
+	let receivedRequest: Request | undefined;
+	let receivedOptions: NormalizedOptions | undefined;
+
+	await t.throwsAsync(
+		ky('https://example.com', {
+			retry: 0,
+			async fetch() {
+				return new Response('', {status: 500});
+			},
+			hooks: {
+				beforeError: [
+					({request, options, error}) => {
+						receivedRequest = request;
+						receivedOptions = options;
+						return error;
+					},
+				],
+			},
+		}),
+	);
+
+	t.true(receivedRequest?.url.includes('example.com'));
+	t.is(receivedOptions?.method, 'GET');
+});
+
+test('beforeError receives request and options for network TypeError', async t => {
+	let receivedRequest: Request | undefined;
+	let receivedOptions: NormalizedOptions | undefined;
+
+	await t.throwsAsync(
+		ky('https://example.com', {
+			retry: 0,
+			async fetch() {
+				throw new TypeError('Failed to fetch');
+			},
+			hooks: {
+				beforeError: [
+					({request, options, error}) => {
+						receivedRequest = request;
+						receivedOptions = options;
+						return error;
+					},
+				],
+			},
+		}),
+	);
+
+	t.true(receivedRequest?.url.includes('example.com'));
+	t.is(receivedOptions?.method, 'GET');
+});
+
+test('beforeError receives request and options for TimeoutError', async t => {
+	let receivedRequest: Request | undefined;
+	let receivedOptions: NormalizedOptions | undefined;
+
+	await t.throwsAsync(
+		ky('https://example.com', {
+			timeout: 1,
+			retry: 0,
+			async fetch() {
+				await delay(100);
+				return new Response('ok');
+			},
+			hooks: {
+				beforeError: [
+					({request, options, error}) => {
+						receivedRequest = request;
+						receivedOptions = options;
+						return error;
+					},
+				],
+			},
+		}),
+	);
+
+	t.true(receivedRequest?.url.includes('example.com'));
+	t.is(receivedOptions?.method, 'GET');
+});
+
+test('beforeError receives options.context', async t => {
+	let receivedContext: unknown;
+
+	await t.throwsAsync(
+		ky('https://example.com', {
+			retry: 0,
+			context: {userId: '123', action: 'test'},
+			async fetch() {
+				return new Response('', {status: 500});
+			},
+			hooks: {
+				beforeError: [
+					({options, error}) => {
+						receivedContext = options.context;
+						return error;
+					},
+				],
+			},
+		}),
+	);
+
+	t.deepEqual(receivedContext, {userId: '123', action: 'test'});
+});
+
+test('beforeError receives request and options when beforeRequest hook throws', async t => {
+	let receivedRequest: Request | undefined;
+	let receivedOptions: NormalizedOptions | undefined;
+
+	await t.throwsAsync(
+		ky('https://example.com', {
+			retry: 0,
+			async fetch() {
+				return new Response('ok');
+			},
+			hooks: {
+				beforeRequest: [
+					() => {
+						throw new Error('beforeRequest failed');
+					},
+				],
+				beforeError: [
+					({request, options, error}) => {
+						receivedRequest = request;
+						receivedOptions = options;
+						return error;
+					},
+				],
+			},
+		}),
+	);
+
+	t.true(receivedRequest?.url.includes('example.com'));
+	t.is(receivedOptions?.method, 'GET');
 });
 
 test('beforeRequest hook can return modified Request with new URL', async t => {


### PR DESCRIPTION
The `beforeError` hook was the only hook missing `request` and `options` in its state object. This adds them for consistency with all other hooks.