### PR TITLE
Fix minor typos and improve backtick consistency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,7 +199,7 @@ Type: `string | URL`
 
 A base URL to [resolve](https://developer.mozilla.org/en-US/docs/Web/API/URL_API/Resolving_relative_references) the `input` against. When the `input` (after applying the `prefix` option) is only a relative URL, such as `'users'`, `'/users'`,  or `'//my-site.com'`, it will be resolved against the `baseUrl` to determine the destination of the request. Otherwise, the `input` is absolute, such as `'https://my-site.com'`, and it will bypass the `baseUrl`.
 
-Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky-instances.
+Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky instances.
 
 If the `baseUrl` itself is relative, it will be resolved against the environment's base URL, such as [`document.baseURI`](https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI) in browsers or `location.href` in Deno (see the `--location` flag).
 
@@ -223,7 +223,7 @@ Type: `string | URL`
 
 A prefix to prepend to the `input` before making the request (and before it is resolved against the `baseUrl`). It can be any valid path or URL, either relative or absolute. A trailing slash `/` is optional and will be added automatically, if needed, when it is joined with `input`. Only takes effect when `input` is a string.
 
-Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky-instances.
+Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky instances.
 
 *In most cases, you should use the `baseUrl` option instead, as it is more consistent with web standards. However, `prefix` is useful if you want origin-relative `input` URLs, such as `/users`, to be treated as if they were page-relative. In other words, the leading slash of the `input` will essentially be ignored, because the `prefix` will become part of the `input` before URL resolution happens.*
 
@@ -1034,7 +1034,7 @@ const options = {
 	}
 };
 
-// Note that response will be `undefined` in case `ky.stop` is returned.
+// Note that `response` will be `undefined` in case `ky.stop` is returned.
 const response = await ky.post('https://example.com', options);
 
 // Using `.text()` or other body methods is not supported.

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ import ky from 'https://esm.sh/ky';
 
 The `input` and `options` are the same as [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch), with additional `options` available (see below).
 
-Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#body) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.Fetch`, these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return `undefined` if body is empty or the response status is `204` instead of throwing a parse error due to an empty body.
+Returns a [`Response` object](https://developer.mozilla.org/en-US/docs/Web/API/Response) with [`Body` methods](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#body) added for convenience. So you can, for example, call `ky.get(input).json()` directly without having to await the `Response` first. When called like that, an appropriate `Accept` header will be set depending on the body method used. Unlike the `Body` methods of `window.fetch`, these will throw an `HTTPError` if the response status is not in the range of `200...299`. Also, `.json()` will return `undefined` if body is empty or the response status is `204` instead of throwing a parse error due to an empty body.
 
 Available body shortcuts: `.json()`, `.text()`, `.formData()`, `.arrayBuffer()`, `.blob()`, and `.bytes()`. The `.bytes()` shortcut is only present when the runtime supports `Response.prototype.bytes()`.
 
@@ -180,7 +180,7 @@ Internally, the standard methods (`GET`, `POST`, `PUT`, `PATCH`, `HEAD` and `DEL
 
 Type: `object` and any other value accepted by [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
 
-Shortcut for sending JSON. Use this instead of the `body` option. Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
+Shortcut for sending JSON. Use this instead of the `body` option. Accepts any plain object or value, which will be stringified using `JSON.stringify()` and sent in the body with the correct header set.
 
 ##### searchParams
 
@@ -248,7 +248,7 @@ Notes:
 Type: `object | number`\
 Default:
 - `limit`: `2`
-- `methods`: `get` `put` `head` `delete` `options` `trace`
+- `methods`: `GET` `PUT` `HEAD` `DELETE` `OPTIONS` `TRACE`
 - `statusCodes`: [`408`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) [`413`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413) [`429`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) [`500`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) [`502`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) [`503`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) [`504`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)
 - `afterStatusCodes`: [`413`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413), [`429`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429), [`503`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503)
 - `maxRetryAfter`: `undefined`

--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ Notes:
 Type: `object | number`\
 Default:
 - `limit`: `2`
-- `methods`: `GET` `PUT` `HEAD` `DELETE` `OPTIONS` `TRACE`
+- `methods`: `get` `put` `head` `delete` `options` `trace`
 - `statusCodes`: [`408`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) [`413`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413) [`429`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) [`500`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) [`502`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) [`503`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) [`504`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)
 - `afterStatusCodes`: [`413`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413), [`429`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429), [`503`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503)
 - `maxRetryAfter`: `undefined`

--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -218,7 +218,7 @@ export class Ky {
 				let processedError: Error = error;
 				for (const hook of ky.#options.hooks.beforeError) {
 					// `request` is the current failing request. `options` intentionally remains the
-					// stable normalized Ky options snapshot for the same reason as HTTPError above.
+					// stable normalized Ky options snapshot for the same reason as `HTTPError` above.
 					// eslint-disable-next-line no-await-in-loop
 					const hookResult: unknown = await hook({
 						request: ky.request,

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -34,7 +34,7 @@ export type KyOptions = {
 	/**
 	Shortcut for sending JSON. Use this instead of the `body` option.
 
-	Accepts any plain object or value, which will be `JSON.stringify()`'d and sent in the body with the correct header set.
+	Accepts any plain object or value, which will be stringified using `JSON.stringify()` and sent in the body with the correct header set.
 	*/
 	json?: unknown;
 

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -113,7 +113,7 @@ export type KyOptions = {
 	/**
 	A base URL to [resolve](https://developer.mozilla.org/en-US/docs/Web/API/URL_API/Resolving_relative_references) the `input` against. When the `input` (after applying the `prefix` option) is only a relative URL, such as `'users'`, `'/users'`,  or `'//my-site.com'`, it will be resolved against the `baseUrl` to determine the destination of the request. Otherwise, the `input` is absolute, such as `'https://my-site.com'`, and it will bypass the `baseUrl`.
 
-	Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky-instances.
+	Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky instances.
 
 	If the `baseUrl` itself is relative, it will be resolved against the environment's base URL, such as [`document.baseURI`](https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI) in browsers or `location.href` in Deno (see the `--location` flag).
 

--- a/source/types/options.ts
+++ b/source/types/options.ts
@@ -137,7 +137,7 @@ export type KyOptions = {
 	/**
 	A prefix to prepend to the `input` before making the request (and before it is resolved against the `baseUrl`). It can be any valid path or URL, either relative or absolute. A trailing slash `/` is optional and will be added automatically, if needed, when it is joined with `input`. Only takes effect when `input` is a string.
 
-	Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky-instances.
+	Useful when used with [`ky.extend()`](#kyextenddefaultoptions) to create niche-specific Ky instances.
 
 	*In most cases, you should use the `baseUrl` option instead, as it is more consistent with web standards. However, `prefix` is useful if you want origin-relative `input` URLs, such as `/users`, to be treated as if they were page-relative. In other words, the leading slash of the `input` will essentially be ignored, because the `prefix` will become part of the `input` before URL resolution happens.*
 

--- a/source/utils/type-guards.ts
+++ b/source/utils/type-guards.ts
@@ -9,7 +9,7 @@ const isErrorType = (error: unknown, cls: {name: string}): boolean =>
 	error instanceof (cls as any) || (error as any)?.name === cls.name;
 
 /**
-Type guard to check if an error is a Ky error.
+Type guard to check if an error is a `KyError`.
 
 Note: `SchemaValidationError` is intentionally not considered a Ky error. `KyError` covers failures in Ky's HTTP lifecycle (bad status, timeout, retry), while schema validation errors originate from the user-provided schema, not from Ky itself.
 
@@ -37,10 +37,10 @@ export function isKyError(error: unknown): error is KyError {
 }
 
 /**
-Type guard to check if an error is an HTTPError.
+Type guard to check if an error is an `HTTPError`.
 
 @param error - The error to check
-@returns `true` if the error is an HTTPError, `false` otherwise
+@returns `true` if the error is an `HTTPError`, `false` otherwise
 
 @example
 ```
@@ -59,10 +59,10 @@ export function isHTTPError<T = unknown>(error: unknown): error is HTTPError<T> 
 }
 
 /**
-Type guard to check if an error is a NetworkError.
+Type guard to check if an error is a `NetworkError`.
 
 @param error - The error to check
-@returns `true` if the error is a NetworkError, `false` otherwise
+@returns `true` if the error is a `NetworkError`, `false` otherwise
 
 @example
 ```
@@ -81,10 +81,10 @@ export function isNetworkError(error: unknown): error is NetworkError {
 }
 
 /**
-Type guard to check if an error is a TimeoutError.
+Type guard to check if an error is a `TimeoutError`.
 
 @param error - The error to check
-@returns `true` if the error is a TimeoutError, `false` otherwise
+@returns `true` if the error is a `TimeoutError`, `false` otherwise
 
 @example
 ```
@@ -103,10 +103,10 @@ export function isTimeoutError(error: unknown): error is TimeoutError {
 }
 
 /**
-Type guard to check if an error is a ForceRetryError.
+Type guard to check if an error is a `ForceRetryError`.
 
 @param error - The error to check
-@returns `true` if the error is a ForceRetryError, `false` otherwise
+@returns `true` if the error is a `ForceRetryError`, `false` otherwise
 
 @example
 ```


### PR DESCRIPTION
# Fix minor typos and improve documentation consistency

## Description
**This PR addresses several minor typos and consistency issues in the `ky` documentation and source code comments to ensure a high-quality, professional appearance and better readability:**

- **Standardized Terminology:** Corrected "Ky-instances" to "Ky instances" in the `readme.md` and type definitions for better style consistency.
- **Improved Syntax Highlighting:** Added missing backticks to key code symbols like `response` and `undefined` in `readme.md` code block comments.
- **Professional JSDoc Formatting:** Added missing backticks to internal error class names (`KyError`, `HTTPError`, `NetworkError`, `TimeoutError`, and `ForceRetryError`) in `source/utils/type-guards.ts` and `source/core/Ky.ts` comments.

## Type of Change
- [x] Documentation update (non-breaking change; fixes typos and formatting)

## Checklist
- [x] My changes follow the code style of this project.
- [x] I have performed a self-review of my own changes.
- [x] My changes generate no new warnings.

# Thank You!