### PR TITLE
fix: isolate tuple searchParams in init hooks

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -84,6 +84,14 @@ const isRequestInstance = (value: unknown): value is Request =>
 const isResponseInstance = (value: unknown): value is Response =>
 	value instanceof globalThis.Response || objectToString.call(value) === '[object Response]';
 
+const cloneSearchParametersForInitHook = (searchParameters: SearchParamsOption | undefined): SearchParamsOption | undefined => {
+	if (Array.isArray(searchParameters)) {
+		return searchParameters.map(parameter => [...parameter]) as SearchParamsOption;
+	}
+
+	return cloneShallow(searchParameters) as SearchParamsOption | undefined;
+};
+
 // Shallow-clone mutable option properties so init hook mutations don't leak across requests.
 function cloneInitHookOptions(options: Options): Options {
 	const clonedOptions: Options = {
@@ -91,7 +99,7 @@ function cloneInitHookOptions(options: Options): Options {
 		json: cloneShallow(options.json),
 		context: cloneShallow(options.context)!,
 		headers: cloneShallow(options.headers)!,
-		searchParams: cloneShallow(options.searchParams) as SearchParamsOption | undefined,
+		searchParams: cloneSearchParametersForInitHook(options.searchParams),
 	};
 
 	if (options.retry !== undefined) {

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -4900,6 +4900,36 @@ test('init hook in-place mutations do not leak across requests', async t => {
 	t.deepEqual(seenRequestIdentifiers, ['1', '2']);
 });
 
+test('init hook tuple searchParams mutations do not leak across requests', async t => {
+	let requestIdentifier = 0;
+	const seenInitialValues: string[] = [];
+	const seenRequestIdentifiers: string[] = [];
+
+	const api = ky.extend({
+		searchParams: [['requestId', 'seed']],
+		hooks: {
+			init: [
+				options => {
+					const searchParameters = options.searchParams as string[][];
+					seenInitialValues.push(searchParameters[0]![1]!);
+					searchParameters[0]![1] = String(++requestIdentifier);
+				},
+			],
+		},
+	});
+
+	const fetch: typeof globalThis.fetch = async request => {
+		seenRequestIdentifiers.push(new URL(request.url).searchParams.get('requestId')!);
+		return new Response('ok');
+	};
+
+	await api.get('https://example.com', {fetch});
+	await api.get('https://example.com', {fetch});
+
+	t.deepEqual(seenInitialValues, ['seed', 'seed']);
+	t.deepEqual(seenRequestIdentifiers, ['1', '2']);
+});
+
 test('init hook in-place retry mutations do not leak across requests', async t => {
 	const seenLimits: number[] = [];
 


### PR DESCRIPTION
## Summary
- isolate `searchParams` tuple arrays before init hooks mutate them
- prevent tuple edits from leaking into later requests on the same instance
- add a regression test covering the supported `[[key, value]]` search params form

## Root cause
`cloneInitHookOptions()` is supposed to give init hooks a request-local mutable copy of the options, but `searchParams` in tuple-array form only got a shallow outer array copy. Mutating an existing tuple like `options.searchParams[0][1] = ...` changed the shared default tuple, so the next request inherited the previous hook mutation.

## Fix
- add a `cloneSearchParametersForInitHook()` helper that deep-copies tuple arrays while preserving the other supported `searchParams` input forms
- keep the existing cloning behavior for strings, objects, and `URLSearchParams`
- add an end-to-end init-hook regression that proves tuple-array defaults no longer leak between requests

## Testing
- `npm run build`
- `npx ava test/hooks.ts --match "init hook*do not leak across requests"`
- `npx ava test/hooks.ts --match "init hook tuple searchParams mutations do not leak across requests"`

## Notes
`npm test` in this Windows checkout still hits upstream `xo` project-service parsing errors for the repo's test files before it reaches AVA. The targeted hook tests and build above passed locally.
