### PR TITLE
Fix `extend()` dropping numeric `retry` limit when merging with an object

### DIFF
--- a/source/utils/merge.ts
+++ b/source/utils/merge.ts
@@ -204,7 +204,7 @@ const appendSearchParameters = (target: any, source: any): URLSearchParams => {
 };
 
 // TODO: Make this strongly-typed (no `any`).
-export const deepMerge = <T>(...sources: Array<Partial<T> | undefined>): T => {
+const deepMergeInternal = <T>(isRoot: boolean, ...sources: Array<Partial<T> | undefined>): T => {
 	let returnValue: any = {};
 	let headers: KyHeadersInit = {};
 	let hooks = {};
@@ -267,12 +267,14 @@ export const deepMerge = <T>(...sources: Array<Partial<T> | undefined>): T => {
 				// `retry` accepts a number as shorthand for `{limit: number}`. Expand it before
 				// merging so extending a numeric `retry` with an object keeps the limit instead
 				// of dropping it (e.g. `ky.create({retry: 3}).extend({retry: {methods: ['get']}})`).
-				if (key === 'retry' && isObject(value) && !isReplace && typeof returnValue[key] === 'number') {
+				// Scoped to the root options level so it never rewrites nested user data that
+				// happens to contain a `retry` key (e.g. a `json` request body).
+				if (isRoot && key === 'retry' && isObject(value) && !isReplace && typeof returnValue[key] === 'number') {
 					returnValue = {...returnValue, [key]: {limit: returnValue[key]}};
 				}
 
 				if (isObject(value) && !isReplace && key in returnValue) {
-					value = deepMerge(returnValue[key], value);
+					value = deepMergeInternal(false, returnValue[key], value);
 				}
 
 				returnValue = {...returnValue, [key]: value};
@@ -317,3 +319,6 @@ export const deepMerge = <T>(...sources: Array<Partial<T> | undefined>): T => {
 
 	return returnValue;
 };
+
+export const deepMerge = <T>(...sources: Array<Partial<T> | undefined>): T =>
+	deepMergeInternal<T>(true, ...sources);

--- a/source/utils/merge.ts
+++ b/source/utils/merge.ts
@@ -264,6 +264,13 @@ export const deepMerge = <T>(...sources: Array<Partial<T> | undefined>): T => {
 					continue;
 				}
 
+				// `retry` accepts a number as shorthand for `{limit: number}`. Expand it before
+				// merging so extending a numeric `retry` with an object keeps the limit instead
+				// of dropping it (e.g. `ky.create({retry: 3}).extend({retry: {methods: ['get']}})`).
+				if (key === 'retry' && isObject(value) && !isReplace && typeof returnValue[key] === 'number') {
+					returnValue = {...returnValue, [key]: {limit: returnValue[key]}};
+				}
+
 				if (isObject(value) && !isReplace && key in returnValue) {
 					value = deepMerge(returnValue[key], value);
 				}

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -452,6 +452,20 @@ test('retry - extending a numeric `retry` with an object keeps the limit', async
 	t.is(requestCount, 4);
 });
 
+test('retry - shorthand expansion does not rewrite nested user data with a `retry` key', async t => {
+	const server = await createHttpTestServer(t);
+	server.post('/', (request, response) => {
+		response.json({body: request.body});
+	});
+
+	// A `retry` key inside the `json` body is user data, not the `retry` option,
+	// so the number-to-`{limit}` shorthand must not touch it.
+	const client = ky.create({json: {retry: 3}}).extend({json: {retry: {foo: 'bar'}}});
+
+	const {body} = await client.post(server.url).json<{body: {retry: unknown}}>();
+	t.deepEqual(body.retry, {foo: 'bar'});
+});
+
 test('doesn\'t retry on 413 with empty statusCodes and methods', async t => {
 	let requestCount = 0;
 

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -433,6 +433,25 @@ test('retry - can provide retry as number', async t => {
 	t.is(requestCount, 5);
 });
 
+test('retry - extending a numeric `retry` with an object keeps the limit', async t => {
+	let requestCount = 0;
+
+	const server = await createHttpTestServer(t);
+	server.get('/', async (_request, response) => {
+		requestCount++;
+		response.sendStatus(408);
+	});
+
+	// `retry: 3` is shorthand for `{limit: 3}`. Extending it with an object
+	// should preserve that limit instead of falling back to the default.
+	const extended = ky.create({retry: 3}).extend({retry: {methods: ['get']}});
+
+	await t.throwsAsync(extended(server.url).text(), {
+		message: /Request Timeout/,
+	});
+	t.is(requestCount, 4);
+});
+
 test('doesn\'t retry on 413 with empty statusCodes and methods', async t => {
 	let requestCount = 0;
 


### PR DESCRIPTION
### Problem

`retry` accepts a number as shorthand for `{limit: number}` (per the docs: *"If `retry` is a number, it will be used as `limit` and other defaults will remain in place."*).

However, when a numeric `retry` is set on a parent instance and then extended with an **object**, the numeric limit is silently dropped and falls back to the default (`2`):

```js
import ky from 'ky';

const api = ky.create({retry: 3});

// Intent: keep limit 3, only narrow the retriable methods.
const extended = api.extend({retry: {methods: ['get']}});

// Bug: `extended` retries with the default limit of 2, not 3.
```

The reverse direction (object on the parent, number on the child) and the all-object case both work correctly — only the *number → object* merge loses data.

### Cause

In `deepMerge`, `retry` is merged like any other nested object. When the parent value is the numeric shorthand (`3`) and the incoming value is an object, the recursion ends up as `deepMerge(3, {methods: ['get']})`. A non-object source is skipped entirely by `deepMerge`, so the `3` is discarded and only `{methods: ['get']}` survives — the limit is lost.

### Fix

Expand the numeric `retry` shorthand to `{limit: number}` before the deep merge, so extending it with an object preserves the limit. This mirrors the documented shorthand semantics and leaves every other case (object → object, object → number replacement, `replaceOption`) unchanged.

```js
deepMerge({retry: 3}, {retry: {methods: ['get']}})
// before: {retry: {methods: ['get']}}
// after:  {retry: {limit: 3, methods: ['get']}}
```

### Test

Added a test in `test/retry.ts` that sets `retry: 3` on a parent, extends it with `retry: {methods: ['get']}`, and asserts the request is attempted `limit + 1` times. It fails on `main` (3 attempts) and passes with the fix (4 attempts).
