### PR TITLE
Fix: validate retry.afterStatusCodes is an array

### DIFF
--- a/source/utils/normalize.ts
+++ b/source/utils/normalize.ts
@@ -41,6 +41,10 @@ export const normalizeRetryOptions = (retry: number | RetryOptions = {}): Intern
 		throw new Error('retry.statusCodes must be an array');
 	}
 
+	if (retry.afterStatusCodes && !Array.isArray(retry.afterStatusCodes)) {
+		throw new Error('retry.afterStatusCodes must be an array');
+	}
+
 	const normalizedRetry = Object.fromEntries(Object.entries({
 		...retry,
 		methods: retry.methods?.map(method => method.toLowerCase()),

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -694,6 +694,19 @@ test('throws when retry.statusCodes is not an array', async t => {
 	});
 });
 
+test('throws when retry.afterStatusCodes is not an array', async t => {
+	const server = await createHttpTestServer(t);
+
+	t.throws(() => {
+		void ky(server.url, {
+			retry: {
+				// @ts-expect-error
+				afterStatusCodes: 413,
+			},
+		});
+	});
+});
+
 test('retry options ignore undefined overrides and keep defaults', async t => {
 	let requestCount = 0;
 


### PR DESCRIPTION
## Bug

`retry.methods` and `retry.statusCodes` both validate that the provided value is an array at construction time, throwing a descriptive error immediately. `retry.afterStatusCodes` was missing this same guard.

Passing a non-array (e.g. a single status code number) silently passes through `normalizeRetryOptions` and only fails later inside `#calculateRetryDelay` as a confusing:

```
TypeError: this.#options.retry.afterStatusCodes.includes is not a function
```

This error appears during a retry attempt — well after construction — making it hard to diagnose.

## Fix

Add the missing validation to `normalizeRetryOptions` so all three array options are consistent:

```ts
if (retry.afterStatusCodes && !Array.isArray(retry.afterStatusCodes)) {
    throw new Error('retry.afterStatusCodes must be an array');
}
```

## Verification

```
npx ava test/retry.ts --match '*afterStatusCodes is not an array*'
```

Result: 1 test passed (new test). Full `npx ava test/retry.ts`: 85 tests passed, 0 failed.

> AI-assisted contribution.