### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,10 @@ It's just a tiny package with no dependencies.
 npm install ky
 ```
 
+```sh
+deno install ky
+```
+
 > [!NOTE]
 > This readme is for the next version of Ky. For the current version, [click here](https://www.npmjs.com/package/ky).
 


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions show `npm install`, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install ky
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install ky`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it to a docs site instead.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
